### PR TITLE
Add support for list formatted K8s Versions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ var (
 	ignoreRemovals     bool
 	targetVersion      string
 	namespace          string
-	listFormat 				 bool
+	listFormat         bool
 )
 
 func init() {

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -116,3 +116,18 @@ func CheckForAPIVersion(file string) ([]*api.Output, error) {
 	}
 	return outputs, nil
 }
+
+// CheckForListOfAPIVersion checks a filename to see if
+// it is a list of api-versioned Kubernetes object.
+// Returns the File object if it is.
+func CheckForListOfAPIVersion(file string) ([]*api.Output, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	outputs, err := api.IsListVersioned(data)
+	if err != nil {
+		return nil, err
+	}
+	return outputs, nil
+}


### PR DESCRIPTION
Problem: Add the ability to use output dump directly from K8s cluster as input into Pluto. When performing command such as `kubectl get all -A -o yaml` into a file, the file format is not digestible by Pluto by default. This PR adds support for list format to Pluto such that Pluto can consume this output directly.

This is currently working however I am adding unit tests to this change. Would love to get feedback on this before moving deeper into unit tests. 