### PR TITLE
Support OIDC Auth Provider

### DIFF
--- a/pkg/helm/kube.go
+++ b/pkg/helm/kube.go
@@ -20,8 +20,9 @@ import (
 	"sync"
 
 	"k8s.io/client-go/kubernetes"
-	// This is required to auth to gcp (i.e. GKE)
+	// This is required to auth to cloud providers (i.e. GKE)
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 


### PR DESCRIPTION
Hi, here is PR for adding OIDC Auth Provider support.
When running `detect-helm` against IBMCloud I got following error:

```
Error creating kubernetes client: no Auth Provider found for name "oidc"
```

Thanks for this awesome project!