### PR TITLE
Better logging/ux for external errors

### DIFF
--- a/pkg/api/versions.go
+++ b/pkg/api/versions.go
@@ -147,7 +147,8 @@ func yamlToStub(data []byte) ([]*Stub, error) {
 			if err == io.EOF {
 				break
 			}
-			return stubs, err
+			klog.Infof("skipping for invalid yaml in manifest: %s", err)
+			continue
 		}
 		stubs = append(stubs, stub)
 	}

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -148,9 +148,9 @@ func Test_containsStub(t *testing.T) {
 		},
 		{
 			name:    "not yaml",
-			data:    []byte("some text\nthat is not yaml"),
+			data:    []byte("*."),
 			want:    nil,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name:    "yaml is stub",

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -110,7 +110,7 @@ func Test_yamlToStub(t *testing.T) {
 			name:    "not yaml",
 			data:    []byte("some text\nthat is not yaml"),
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "yaml is stub",
@@ -150,7 +150,7 @@ func Test_containsStub(t *testing.T) {
 			name:    "not yaml",
 			data:    []byte("some text\nthat is not yaml"),
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "yaml is stub",

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -108,9 +108,9 @@ func Test_yamlToStub(t *testing.T) {
 		},
 		{
 			name:    "not yaml",
-			data:    []byte("some text\nthat is not yaml"),
+			data:    []byte("*."),
 			want:    nil,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name:    "yaml is stub",

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -22,6 +22,7 @@ import (
 	driverv2 "helm.sh/helm/pkg/storage/driver"
 	helmstoragev3 "helm.sh/helm/v3/pkg/storage"
 	driverv3 "helm.sh/helm/v3/pkg/storage/driver"
+	"k8s.io/klog"
 
 	"github.com/fairwindsops/pluto/pkg/api"
 )
@@ -107,7 +108,8 @@ func (h *Helm) getReleasesVersionTwo() error {
 		}
 		deployed, err := helmClient.Deployed(release.Name)
 		if err != nil {
-			return fmt.Errorf("error determining most recent deployed for '%s'\n   %w", release.Name, err)
+			klog.Infof("cannot determine most recent deployed for %s - %s", release.Name, err)
+			continue
 		}
 		if release.Version != deployed.Version {
 			continue
@@ -138,7 +140,8 @@ func (h *Helm) getReleasesVersionThree() error {
 	for _, release := range list {
 		deployed, err := helmClient.Deployed(release.Name)
 		if err != nil {
-			return fmt.Errorf("error determining most recent deployed for '%s'\n   %w", release.Name, err)
+			klog.Infof("cannot determine most recent deployed for %s - %s", release.Name, err)
+			continue
 		}
 		if release.Version != deployed.Version {
 			continue
@@ -157,6 +160,7 @@ func (h *Helm) getReleasesVersionThree() error {
 
 func (h *Helm) findVersions() error {
 	for _, release := range h.Releases {
+		klog.V(2).Infof("parsing release %s", release.Name)
 		outList, err := h.checkForAPIVersion([]byte(release.Manifest))
 		if err != nil {
 			return fmt.Errorf("error parsing release '%s'\n   %w", release.Name, err)


### PR DESCRIPTION
This change allows the run of checks to continue if an error is encountered by an external package such as yaml or helm. For instance, if there is malformed yaml at any point it will log out the error and continue on to the next manifest instead of bailing out of the program completely.

This allows you to still get output of deprecated/removed apiVersions in other manifests and warn you that you are missing information for manifests with malformed yaml (or whatever other error it may encounter, such as helm mentioning there are `no deployed releases`

fixes #82 