### PR TITLE
remove Scratch layers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,16 @@ workflows:
   test:
     jobs:
       - test
+      - rok8s-scripts/kubernetes_e2e_tests:
+          requires:
+            - test
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              ignore: /.*/
+          name: functional tests
+          <<: *e2e_config
       - rok8s-scripts/docker_build_and_push:
           name: build-container
           docker-push: false
@@ -76,6 +86,7 @@ workflows:
           config_file: .circleci/build.config
           requires:
             - test
+            - functional tests
           filters:
             branches:
               only: /pull\/[0-9]+/
@@ -91,19 +102,13 @@ workflows:
           username: fairwinds+circleci
           requires:
             - test
+            - functional tests
           filters:
             branches:
               ignore: /pull\/[0-9]+/
 
   release:
     jobs:
-      - test:
-          filters:
-            branches:
-              only: /.*/
-      - rok8s-scripts/kubernetes_e2e_tests:
-          name: run functional tests
-          <<: *e2e_config
       - release_binary:
           filters:
             branches:
@@ -120,8 +125,6 @@ workflows:
           password-variable: "fairwinds_quay_token"
           registry: quay.io
           username: fairwinds+circleci
-          requires:
-            - test
           filters:
             branches:
               ignore: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,11 @@ COPY . .
 RUN go get github.com/markbates/pkger/cmd/pkger
 RUN VERSION=$version COMMIT=$commit make build-linux
 
-
-FROM alpine:3.12.0 as alpine
+FROM alpine:3.12
 RUN apk --no-cache --update add ca-certificates tzdata && update-ca-certificates
-
-
 
 USER nobody
 COPY --from=build-env /go/src/github.com/fairwindsops/pluto /
 
 WORKDIR /opt/app
-
 ENTRYPOINT ["/pluto"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,6 @@ FROM alpine:3.12.0 as alpine
 RUN apk --no-cache --update add ca-certificates tzdata && update-ca-certificates
 
 
-FROM scratch
-COPY --from=alpine /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=alpine /etc/passwd /etc/passwd
 
 USER nobody
 COPY --from=build-env /go/src/github.com/fairwindsops/pluto /


### PR DESCRIPTION
Pluto doesn't have the `--output-file` function, but it also doesn't have a shell. We need one of these to enable Insights integration I think because Insights needs a generated report file. I removed all of the Scratch lines and left it on the alpine image. 