### PR TITLE
Fix JSON/YAML output when there are no outputs

### DIFF
--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -33,8 +33,8 @@ type Instance struct {
 
 // DisplayOutput prints the output based on desired variables
 func (instance *Instance) DisplayOutput() error {
-	if len(instance.Outputs) == 0 {
-		fmt.Println("There were no apiVersions found that match our records.")
+	if len(instance.Outputs) == 0 && (instance.OutputFormat == "normal" || instance.OutputFormat == "wide") {
+		fmt.Println("There were no resources found with known deprecated apiVersions.")
 		return nil
 	}
 	instance.filterOutput()

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -230,7 +230,7 @@ func ExampleInstance_DisplayOutput_zeroLength() {
 	}
 	_ = instance.DisplayOutput()
 
-	// Output: There were no apiVersions found that match our records.
+	// Output: There were no resources found with known deprecated apiVersions.
 }
 
 func TestGetReturnCode(t *testing.T) {


### PR DESCRIPTION
We're running
```
$ pluto detect-helm -ojson > /output/pluto.json;
```

When there are no deprecated resources in the cluster, this results in
```
$ cat /output/pluto.json
There were no apiVersions found that match our records.
```

which is not valid JSON