### PR TITLE
Refactor output columns into interfaces. Add custom output option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,18 +55,6 @@ var outputOptions = []string{
 	"custom",
 }
 
-var possibleColumns = []string{
-	"NAME",
-	"NAMESPACE",
-	"KIND",
-	"VERSION",
-	"REPLACEMENT",
-	"DEPRECATED",
-	"DEPRECATED IN",
-	"REMOVED",
-	"REMOVED IN",
-}
-
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&ignoreDeprecations, "ignore-deprecations", false, "Ignore the default behavior to exit 2 if deprecated apiVersions are found.")
 	rootCmd.PersistentFlags().BoolVar(&ignoreRemovals, "ignore-removals", false, "Ignore the default behavior to exit 3 if removed apiVersions are found.")
@@ -121,8 +109,8 @@ var rootCmd = &cobra.Command{
 
 			customColumns = tempColumns
 			for _, c := range customColumns {
-				if !stringInSlice(c, possibleColumns) {
-					return fmt.Errorf("invalid custom column option %s - must be one of %v", c, possibleColumns)
+				if !stringInSlice(c, api.PossibleColumnNames) {
+					return fmt.Errorf("invalid custom column option %s - must be one of %v", c, api.PossibleColumnNames)
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,10 +72,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&additionalVersionsFile, "additional-versions", "f", "", "Additional deprecated versions file to add to the list. Cannot contain any existing versions")
 	rootCmd.PersistentFlags().StringToStringVarP(&targetVersions, "target-versions", "t", targetVersions, "A map of targetVersions to use. This flag supersedes all defaults in version files.")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "normal", "The output format to use. (normal|wide|custom|json|yaml)")
-	rootCmd.PersistentFlags().StringSliceVar(&customColumns, "columns", nil, "A list of columns to pring when using --output custom")
+	rootCmd.PersistentFlags().StringSliceVar(&customColumns, "columns", nil, "A list of columns to print when using --output custom")
 
 	rootCmd.AddCommand(detectFilesCmd)
-	detectFilesCmd.PersistentFlags().StringVarP(&directory, "directory", "d", "", "The directory to scan. If blank, defaults to current workding dir.")
+	detectFilesCmd.PersistentFlags().StringVarP(&directory, "directory", "d", "", "The directory to scan. If blank, defaults to current working dir.")
 
 	rootCmd.AddCommand(detectHelmCmd)
 	detectHelmCmd.PersistentFlags().StringVar(&helmVersion, "helm-version", "3", "Helm version in current cluster (2|3)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&ignoreRemovals, "ignore-removals", false, "Ignore the default behavior to exit 3 if removed apiVersions are found.")
 	rootCmd.PersistentFlags().StringVarP(&additionalVersionsFile, "additional-versions", "f", "", "Additional deprecated versions file to add to the list. Cannot contain any existing versions")
 	rootCmd.PersistentFlags().StringToStringVarP(&targetVersions, "target-versions", "t", targetVersions, "A map of targetVersions to use. This flag supersedes all defaults in version files.")
-	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "normal", "The output format to use. (normal|wide|json|yaml)")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "normal", "The output format to use. (normal|wide|custom-columns|json|yaml)")
 
 	rootCmd.AddCommand(detectFilesCmd)
 	detectFilesCmd.PersistentFlags().StringVarP(&directory, "directory", "d", "", "The directory to scan. If blank, defaults to current workding dir.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/fairwindsops/pluto/pkg/api"
 	"github.com/fairwindsops/pluto/pkg/finder"
@@ -112,6 +113,13 @@ var rootCmd = &cobra.Command{
 			if len(customColumns) < 1 {
 				return fmt.Errorf("when --output=custom you must specify --columns")
 			}
+			// Uppercase all columns entered on CLI
+			var tempColumns []string
+			for _, colString := range customColumns {
+				tempColumns = append(tempColumns, strings.ToUpper(colString))
+			}
+
+			customColumns = tempColumns
 			for _, c := range customColumns {
 				if !stringInSlice(c, possibleColumns) {
 					return fmt.Errorf("invalid custom column option %s - must be one of %v", c, possibleColumns)

--- a/e2e/tests/00_static_files.yaml
+++ b/e2e/tests/00_static_files.yaml
@@ -46,3 +46,11 @@ testcases:
     - result.code ShouldEqual 3
     - result.systemout ShouldContainSubstring "NAME        NAMESPACE   KIND         VERSION              REPLACEMENT   DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN"
     - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   Deployment   extensions/v1beta1   apps/v1       true         v1.9.0          true      v1.16.0"
+
+- name: static files custom
+  steps:
+  - script: pluto detect-files -d assets/ -o custom --columns "NAME,NAMESPACE,VERSION,KIND,DEPRECATED,DEPRECATED IN"
+    assertions:
+    - result.code ShouldEqual 3
+    - result.systemout ShouldContainSubstring "NAME        NAMESPACE   KIND         VERSION              DEPRECATED   DEPRECATED IN"
+    - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   Deployment   extensions/v1beta1   true         v1.9.0"

--- a/e2e/tests/03-cli-validation.yaml
+++ b/e2e/tests/03-cli-validation.yaml
@@ -38,3 +38,10 @@ testcases:
     - result.code ShouldEqual 1
     - result.systemerr ShouldContainSubstring "invalid custom column option FOO"
     - result.systemerr ShouldContainSubstring "E0713"
+- name: Custom output with no columns falg
+  steps:
+  - script: pluto detect-files -d assets/deprecated116 --target-versions foo=vfoo -o custom
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "when --output=custom you must specify --columns"
+    - result.systemerr ShouldContainSubstring "E0713"

--- a/e2e/tests/03-cli-validation.yaml
+++ b/e2e/tests/03-cli-validation.yaml
@@ -37,11 +37,9 @@ testcases:
     assertions:
     - result.code ShouldEqual 1
     - result.systemerr ShouldContainSubstring "invalid custom column option FOO"
-    - result.systemerr ShouldContainSubstring "E0713"
 - name: Custom output with no columns falg
   steps:
   - script: pluto detect-files -d assets/deprecated116 --target-versions foo=vfoo -o custom
     assertions:
     - result.code ShouldEqual 1
     - result.systemerr ShouldContainSubstring "when --output=custom you must specify --columns"
-    - result.systemerr ShouldContainSubstring "E0713"

--- a/e2e/tests/03-cli-validation.yaml
+++ b/e2e/tests/03-cli-validation.yaml
@@ -31,3 +31,10 @@ testcases:
     assertions:
     - result.code ShouldEqual 0
     - result.systemout ShouldContainSubstring "AnotherCRD                     someother/v1beta1                      v1.9.0          v1.16.0      apps/v1"
+- name: Pass bad column list to custom
+  steps:
+  - script: pluto detect-files -d assets/deprecated116 --target-versions foo=vfoo -o custom --columns "FOO"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "invalid custom column option FOO"
+    - result.systemerr ShouldContainSubstring "E0713"

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -1,0 +1,101 @@
+package api
+
+import "fmt"
+
+// Column is an interface for printing columns
+type column interface {
+	header() string
+	value(output *Output) string
+}
+
+type columnList map[int]column
+
+// name is the output name
+type name struct{}
+
+func (n name) header() string              { return "NAME" }
+func (n name) value(output *Output) string { return output.Name }
+
+// namespace is the output namespace if available
+type namespace struct{}
+
+func (ns namespace) header() string { return "NAMESPACE" }
+func (ns namespace) value(output *Output) string {
+	if output.Namespace == "" {
+		return "<UNKNOWN>"
+	}
+	return output.Namespace
+}
+
+// kind is the output apiVersion kind
+type kind struct{}
+
+func (k kind) header() string              { return "KIND" }
+func (k kind) value(output *Output) string { return output.APIVersion.Kind }
+
+// version is the output apiVersion
+type version struct{}
+
+func (v version) header() string              { return "VERSION" }
+func (v version) value(output *Output) string { return output.APIVersion.Name }
+
+// replacement is the output replacement apiVersion
+type replacement struct{}
+
+func (r replacement) header() string              { return "REPLACEMENT" }
+func (r replacement) value(output *Output) string { return output.APIVersion.ReplacementAPI }
+
+// deprecated is the output for the boolean Deprecated
+type deprecated struct{}
+
+func (d deprecated) header() string              { return "DEPRECATED" }
+func (d deprecated) value(output *Output) string { return fmt.Sprintf("%t", output.Deprecated) }
+
+// removed is the output for the boolean Deprecated
+type removed struct{}
+
+func (r removed) header() string              { return "REMOVED" }
+func (r removed) value(output *Output) string { return fmt.Sprintf("%t", output.Removed) }
+
+// deprecatedIn is the string value of when an output was deprecated
+type deprecatedIn struct{}
+
+func (di deprecatedIn) header() string              { return "DEPRECATED IN" }
+func (di deprecatedIn) value(output *Output) string { return output.APIVersion.DeprecatedIn }
+
+// removedIn is the string value of when an output was deprecated
+type removedIn struct{}
+
+func (ri removedIn) header() string              { return "REMOVED IN" }
+func (ri removedIn) value(output *Output) string { return output.APIVersion.RemovedIn }
+
+// normalColumns returns the list of columns for -onormal
+func (instance *Instance) normalColumns() columnList {
+
+	columnList := columnList{
+		0: new(name),
+		1: new(kind),
+		2: new(version),
+		3: new(replacement),
+		4: new(removed),
+		5: new(deprecated),
+	}
+	return columnList
+}
+
+// wideColumns returns the list of columns for -owide
+func (instance *Instance) wideColumns() columnList {
+
+	columnList := columnList{
+		0: new(name),
+		1: new(namespace),
+		2: new(kind),
+		3: new(version),
+		4: new(replacement),
+		5: new(deprecated),
+		6: new(deprecatedIn),
+		7: new(removed),
+		8: new(removedIn),
+	}
+	return columnList
+}

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -71,7 +71,6 @@ func (ri removedIn) value(output *Output) string { return output.APIVersion.Remo
 
 // normalColumns returns the list of columns for -onormal
 func (instance *Instance) normalColumns() columnList {
-
 	columnList := columnList{
 		0: new(name),
 		1: new(kind),
@@ -85,7 +84,6 @@ func (instance *Instance) normalColumns() columnList {
 
 // wideColumns returns the list of columns for -owide
 func (instance *Instance) wideColumns() columnList {
-
 	columnList := columnList{
 		0: new(name),
 		1: new(namespace),
@@ -102,7 +100,6 @@ func (instance *Instance) wideColumns() columnList {
 
 // customnColumns returns a custom list of columns based on names
 func (instance *Instance) customColumns() columnList {
-
 	possibleColumns := []column{
 		new(name),
 		new(namespace),

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -10,6 +10,31 @@ type column interface {
 
 type columnList map[int]column
 
+//PossibleColumnNames is the list of implmented columns
+var PossibleColumnNames = []string{
+	"NAME",
+	"NAMESPACE",
+	"KIND",
+	"VERSION",
+	"REPLACEMENT",
+	"DEPRECATED",
+	"DEPRECATED IN",
+	"REMOVED",
+	"REMOVED IN",
+}
+
+var possibleColumns = []column{
+	new(name),
+	new(namespace),
+	new(kind),
+	new(version),
+	new(replacement),
+	new(deprecated),
+	new(deprecatedIn),
+	new(removed),
+	new(removedIn),
+}
+
 // name is the output name
 type name struct{}
 
@@ -100,18 +125,6 @@ func (instance *Instance) wideColumns() columnList {
 
 // customColumns returns a custom list of columns based on names
 func (instance *Instance) customColumns() columnList {
-	possibleColumns := []column{
-		new(name),
-		new(namespace),
-		new(kind),
-		new(version),
-		new(replacement),
-		new(deprecated),
-		new(deprecatedIn),
-		new(removed),
-		new(removedIn),
-	}
-
 	var outputColumns = make(map[int]column)
 	for _, d := range instance.CustomColumns {
 		for i, c := range possibleColumns {

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -98,7 +98,7 @@ func (instance *Instance) wideColumns() columnList {
 	return columnList
 }
 
-// customnColumns returns a custom list of columns based on names
+// customColumns returns a custom list of columns based on names
 func (instance *Instance) customColumns() columnList {
 	possibleColumns := []column{
 		new(name),

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -99,3 +99,29 @@ func (instance *Instance) wideColumns() columnList {
 	}
 	return columnList
 }
+
+// customnColumns returns a custom list of columns based on names
+func (instance *Instance) customColumns() columnList {
+
+	possibleColumns := []column{
+		new(name),
+		new(namespace),
+		new(kind),
+		new(version),
+		new(replacement),
+		new(deprecated),
+		new(deprecatedIn),
+		new(removed),
+		new(removedIn),
+	}
+
+	var outputColumns = make(map[int]column)
+	for _, d := range instance.CustomColumns {
+		for i, c := range possibleColumns {
+			if d == c.header() {
+				outputColumns[i] = c
+			}
+		}
+	}
+	return outputColumns
+}

--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -26,7 +26,8 @@ type Output struct {
 	Deprecated bool `json:"deprecated" yaml:"deprecated"`
 	// Removed is a boolean indicating whether or not the version has been removed
 	Removed bool `json:"removed" yaml:"removed"`
-	// CustomColumns is a list of column headers you want to show
+	// CustomColumns is a list of column headers to be displayed when -ocustom
+	CustomColumns []string `json:"-" yaml:"-"`
 }
 
 // Instance is an instance of the API. This holds configuration for a "run" of Pluto
@@ -66,7 +67,7 @@ func (instance *Instance) DisplayOutput() error {
 			return err
 		}
 		return nil
-	case "custom-columns":
+	case "custom":
 		c := instance.customColumns()
 		t := instance.tabOut(c)
 		err = t.Flush()
@@ -85,8 +86,6 @@ func (instance *Instance) DisplayOutput() error {
 			return err
 		}
 		fmt.Println(string(outData))
-	default:
-		fmt.Println("output format should be one of (json,yaml,normal,wide)")
 	}
 	return nil
 }

--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -26,6 +26,7 @@ type Output struct {
 	Deprecated bool `json:"deprecated" yaml:"deprecated"`
 	// Removed is a boolean indicating whether or not the version has been removed
 	Removed bool `json:"removed" yaml:"removed"`
+	// CustomColumns is a list of column headers you want to show
 }
 
 // Instance is an instance of the API. This holds configuration for a "run" of Pluto
@@ -36,6 +37,7 @@ type Instance struct {
 	OutputFormat       string            `json:"-" yaml:"-"`
 	TargetVersions     map[string]string `json:"target-versions,omitempty" yaml:"target-versions,omitempty"`
 	DeprecatedVersions []Version         `json:"-" yaml:"-"`
+	CustomColumns      []string          `json:"-" yaml:"-"`
 }
 
 // DisplayOutput prints the output based on desired variables
@@ -64,6 +66,13 @@ func (instance *Instance) DisplayOutput() error {
 			return err
 		}
 		return nil
+	case "custom-columns":
+		c := instance.customColumns()
+		t := instance.tabOut(c)
+		err = t.Flush()
+		if err != nil {
+			return err
+		}
 	case "json":
 		outData, err = json.Marshal(instance)
 		if err != nil {

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -107,7 +107,7 @@ func ExampleInstance_DisplayOutput_custom() {
 			testOutput1,
 			testOutput2,
 		},
-		OutputFormat:  "custom-columns",
+		OutputFormat:  "custom",
 		CustomColumns: []string{"NAMESPACE", "NAME", "DEPRECATED IN", "DEPRECATED", "REPLACEMENT", "VERSION", "KIND"},
 	}
 	_ = instance.DisplayOutput()
@@ -188,22 +188,6 @@ func ExampleInstance_DisplayOutput_noOutput() {
 	_ = instance.DisplayOutput()
 
 	// Output: No output to display
-}
-
-func ExampleInstance_DisplayOutput_badFormat() {
-	instance := &Instance{
-		TargetVersions: map[string]string{
-			"foo": "v1.16.0",
-		},
-		Outputs: []*Output{
-			testOutput1,
-			testOutput2,
-		},
-		OutputFormat: "foo",
-	}
-	_ = instance.DisplayOutput()
-
-	// Output: output format should be one of (json,yaml,normal,wide)
 }
 
 func ExampleInstance_DisplayOutput_zeroLength() {

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -98,6 +98,26 @@ func ExampleInstance_DisplayOutput_wide() {
 	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- true----- v1.16.0-----
 }
 
+func ExampleInstance_DisplayOutput_custom() {
+	instance := &Instance{
+		TargetVersions: map[string]string{
+			"foo": "v1.16.0",
+		},
+		Outputs: []*Output{
+			testOutput1,
+			testOutput2,
+		},
+		OutputFormat:  "custom-columns",
+		CustomColumns: []string{"NAMESPACE", "NAME", "DEPRECATED IN", "DEPRECATED", "REPLACEMENT", "VERSION", "KIND"},
+	}
+	_ = instance.DisplayOutput()
+
+	// Output:
+	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN--
+	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0---------
+	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0---------
+}
+
 func ExampleInstance_DisplayOutput_json() {
 	instance := &Instance{
 		TargetVersions: map[string]string{


### PR DESCRIPTION
This should make dealing with columns easier. You define the interface of the column once, and then add it to the
proper output column list. Right now no output changes are made, just the underlying code to print them.

In theory, this will make implementing different output types easier.

Fixes #95

Paves the way for #96 by simply modifying the normalColumns and wideColumns functions.