### PR TITLE
Add filepath as a possible custom column

### DIFF
--- a/e2e/tests/00_static_files.yaml
+++ b/e2e/tests/00_static_files.yaml
@@ -32,13 +32,6 @@ testcases:
     - result.code ShouldEqual 0
     - result.systemout ShouldContainSubstring "No output to display"
 
-- name: static files json
-  steps:
-  - script: pluto detect-files -d assets/ -ojson
-    assertions:
-    - result.code ShouldEqual 3
-    - result.systemout ShouldEqual '{"items":[{"name":"utilities","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"k8s"},"deprecated":true,"removed":true}],"target-versions":{"cert-manager":"v0.15.1","istio":"v1.6.0","k8s":"v1.16.0"}}'
-
 - name: static files wide
   steps:
   - script: pluto detect-files -d assets/ -owide
@@ -49,11 +42,19 @@ testcases:
 
 - name: static files custom
   steps:
-  - script: pluto detect-files -d assets/ -o custom --columns "NAME,NAMESPACE,VERSION,KIND,DEPRECATED,DEPRECATED IN"
+  - script: pluto detect-files -d assets/ -o custom --columns "NAME,NAMESPACE,VERSION,KIND,DEPRECATED,DEPRECATED IN,component"
     assertions:
     - result.code ShouldEqual 3
-    - result.systemout ShouldContainSubstring "NAME        NAMESPACE   KIND         VERSION              DEPRECATED   DEPRECATED IN"
-    - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   Deployment   extensions/v1beta1   true         v1.9.0"
+    - result.systemout ShouldContainSubstring "NAME        NAMESPACE   KIND         VERSION              DEPRECATED   DEPRECATED IN   COMPONENT"
+    - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   Deployment   extensions/v1beta1   true         v1.9.0          k8s"
+
+- name: static files show file path
+  steps:
+  - script: pluto detect-files -d assets/ -o custom --columns "filepath"
+    assertions:
+    - result.code ShouldEqual 3
+    - result.systemout ShouldContainSubstring "FILEPATH"
+    - result.systemout ShouldContainSubstring "tests/assets/deprecated116/deployment-extensions-v1beta1.yaml"
 
 - name: static files no output due to no matching components
   steps:

--- a/e2e/tests/01_helm-detect-3.yaml
+++ b/e2e/tests/01_helm-detect-3.yaml
@@ -51,6 +51,13 @@ testcases:
     - result.systemout ShouldContainSubstring "NAME                           NAMESPACE   KIND         VERSION              REPLACEMENT   DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN"
     - result.systemout ShouldContainSubstring "test/test-helm3chart-v1beta1   default     Deployment   extensions/v1beta1   apps/v1       true         v1.9.0          true      v1.16.0"
 
+- name: helm detect -ojson
+  steps:
+  - script: pluto detect-helm --helm-version=3 -ojson --target-versions k8s=v1.16.0
+    assertions:
+    - result.code ShouldEqual 3
+    - result.systemout ShouldEqual {"items":[{"name":"test/test-helm3chart-v1beta1","namespace":"default","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"k8s"},"deprecated":true,"removed":true}],"target-versions":{"cert-manager":"v0.15.1","istio":"v1.6.0","k8s":"v1.16.0"}}
+
 - name: cleanup
   steps:
   - script: |

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -13,6 +13,7 @@ type columnList map[int]column
 //PossibleColumnNames is the list of implmented columns
 var PossibleColumnNames = []string{
 	"NAME",
+	"FILEPATH",
 	"NAMESPACE",
 	"KIND",
 	"VERSION",
@@ -35,6 +36,7 @@ var possibleColumns = []column{
 	new(removed),
 	new(removedIn),
 	new(component),
+	new(filepath),
 }
 
 // name is the output name
@@ -42,6 +44,17 @@ type name struct{}
 
 func (n name) header() string              { return "NAME" }
 func (n name) value(output *Output) string { return output.Name }
+
+// filepath is the full path of the file
+type filepath struct{}
+
+func (f filepath) header() string { return "FILEPATH" }
+func (f filepath) value(output *Output) string {
+	if output.FilePath == "" {
+		return "<UNKNOWN>"
+	}
+	return output.FilePath
+}
 
 // namespace is the output namespace if available
 type namespace struct{}

--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -17,6 +17,8 @@ type Output struct {
 	// Name is the name of the object in question.
 	// This might be an object name, or a release
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// FilePath is the full path of the file if the output came from a file
+	FilePath string `json:"filePath,omitempty" yaml:"filePath,omitempty"`
 	// Namespace is the namespace that the object is in
 	// The output may resolve this to UNKNOWN if there is no way of determining it
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -23,6 +23,7 @@ import (
 var testOutput1 = &Output{
 	Name:      "some name one",
 	Namespace: "pluto-namespace",
+	FilePath:  "path-to-file",
 	APIVersion: &Version{
 		Name:           "extensions/v1beta1",
 		Kind:           "Deployment",
@@ -111,14 +112,14 @@ func ExampleInstance_DisplayOutput_custom() {
 		},
 		OutputFormat:  "custom",
 		Components:    []string{"foo"},
-		CustomColumns: []string{"NAMESPACE", "NAME", "DEPRECATED IN", "DEPRECATED", "REPLACEMENT", "VERSION", "KIND"},
+		CustomColumns: []string{"NAMESPACE", "NAME", "DEPRECATED IN", "DEPRECATED", "REPLACEMENT", "VERSION", "KIND", "COMPONENT", "FILEPATH"},
 	}
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN--
-	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0---------
-	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0---------
+	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN-- COMPONENT-- FILEPATH------
+	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- foo-------- path-to-file--
+	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- foo-------- <UNKNOWN>-----
 }
 
 func ExampleInstance_DisplayOutput_json() {
@@ -136,7 +137,7 @@ func ExampleInstance_DisplayOutput_json() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// {"items":[{"name":"some name one","namespace":"pluto-namespace","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true},{"name":"some name two","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true}],"target-versions":{"foo":"v1.16.0"}}
+	// {"items":[{"name":"some name one","filePath":"path-to-file","namespace":"pluto-namespace","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true},{"name":"some name two","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true}],"target-versions":{"foo":"v1.16.0"}}
 }
 
 func ExampleInstance_DisplayOutput_yaml() {
@@ -156,6 +157,7 @@ func ExampleInstance_DisplayOutput_yaml() {
 	// Output:
 	// items:
 	// - name: some name one
+	//   filePath: path-to-file
 	//   namespace: pluto-namespace
 	//   api:
 	//     version: extensions/v1beta1

--- a/pkg/api/versions.go
+++ b/pkg/api/versions.go
@@ -86,7 +86,10 @@ func (instance *Instance) checkVersion(stub *Stub) *Version {
 // version in the VersionList
 func (instance *Instance) IsVersioned(data []byte) ([]*Output, error) {
 	var outputs []*Output
-	stubs := containsStub(data)
+	stubs, err := containsStub(data)
+	if err != nil {
+		return nil, err
+	}
 	if len(stubs) > 0 {
 		for _, stub := range stubs {
 			var output Output
@@ -106,21 +109,21 @@ func (instance *Instance) IsVersioned(data []byte) ([]*Output, error) {
 }
 
 // containsStub checks to see if a []byte has a stub in it
-func containsStub(data []byte) []*Stub {
+func containsStub(data []byte) ([]*Stub, error) {
 	klog.V(10).Infof("\n%s", string(data))
 	stub, err := jsonToStub(data)
 	if err != nil {
 		klog.V(8).Infof("invalid json: %s", err.Error())
 	} else {
-		return stub
+		return stub, nil
 	}
 	stub, err = yamlToStub(data)
 	if err != nil {
 		klog.V(8).Infof("invalid yaml: %s", err.Error())
 	} else {
-		return stub
+		return stub, nil
 	}
-	return nil
+	return nil, err
 }
 
 func jsonToStub(data []byte) ([]*Stub, error) {

--- a/pkg/api/versions.go
+++ b/pkg/api/versions.go
@@ -284,9 +284,6 @@ func UnMarshalVersions(data []byte) ([]Version, map[string]string, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not unmarshal versions file from data: %s", err.Error())
 	}
-	if versionFile.TargetVersions == nil {
-		return versionFile.DeprecatedVersions, nil, nil
-	}
 	return versionFile.DeprecatedVersions, versionFile.TargetVersions, nil
 
 }

--- a/pkg/api/versions.go
+++ b/pkg/api/versions.go
@@ -86,10 +86,7 @@ func (instance *Instance) checkVersion(stub *Stub) *Version {
 // version in the VersionList
 func (instance *Instance) IsVersioned(data []byte) ([]*Output, error) {
 	var outputs []*Output
-	stubs, err := containsStub(data)
-	if err != nil {
-		return nil, err
-	}
+	stubs := containsStub(data)
 	if len(stubs) > 0 {
 		for _, stub := range stubs {
 			var output Output
@@ -109,21 +106,21 @@ func (instance *Instance) IsVersioned(data []byte) ([]*Output, error) {
 }
 
 // containsStub checks to see if a []byte has a stub in it
-func containsStub(data []byte) ([]*Stub, error) {
+func containsStub(data []byte) []*Stub {
 	klog.V(10).Infof("\n%s", string(data))
 	stub, err := jsonToStub(data)
 	if err != nil {
 		klog.V(8).Infof("invalid json: %s", err.Error())
 	} else {
-		return stub, nil
+		return stub
 	}
 	stub, err = yamlToStub(data)
 	if err != nil {
 		klog.V(8).Infof("invalid yaml: %s", err.Error())
 	} else {
-		return stub, nil
+		return stub
 	}
-	return nil, err
+	return nil
 }
 
 func jsonToStub(data []byte) ([]*Stub, error) {

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -135,64 +135,51 @@ func Test_yamlToStub(t *testing.T) {
 
 func Test_containsStub(t *testing.T) {
 	tests := []struct {
-		name    string
-		data    []byte
-		want    []*Stub
-		wantErr bool
+		name string
+		data []byte
+		want []*Stub
 	}{
 		{
-			name:    "yaml not stub",
-			data:    []byte("foo: bar"),
-			want:    []*Stub{{}},
-			wantErr: false,
+			name: "yaml not stub",
+			data: []byte("foo: bar"),
+			want: []*Stub{{}},
 		},
 		{
-			name:    "not yaml",
-			data:    []byte("*."),
-			want:    nil,
-			wantErr: true,
+			name: "not yaml",
+			data: []byte("*."),
+			want: nil,
 		},
 		{
-			name:    "yaml is stub",
-			data:    []byte("kind: foo\napiVersion: bar"),
-			want:    []*Stub{{Kind: "foo", APIVersion: "bar"}},
-			wantErr: false,
+			name: "yaml is stub",
+			data: []byte("kind: foo\napiVersion: bar"),
+			want: []*Stub{{Kind: "foo", APIVersion: "bar"}},
 		},
 		{
-			name:    "json not stub",
-			data:    []byte("{}"),
-			want:    []*Stub{{}},
-			wantErr: false,
+			name: "json not stub",
+			data: []byte("{}"),
+			want: []*Stub{{}},
 		},
 		{
-			name:    "empty string",
-			data:    []byte(""),
-			want:    nil,
-			wantErr: false,
+			name: "empty string",
+			data: []byte(""),
+			want: nil,
 		},
 		{
-			name:    "no data",
-			data:    []byte{},
-			want:    nil,
-			wantErr: false,
+			name: "no data",
+			data: []byte{},
+			want: nil,
 		},
 		{
-			name:    "json is stub",
-			data:    []byte(`{"kind": "foo", "apiVersion": "bar"}`),
-			want:    []*Stub{{Kind: "foo", APIVersion: "bar"}},
-			wantErr: false,
+			name: "json is stub",
+			data: []byte(`{"kind": "foo", "apiVersion": "bar"}`),
+			want: []*Stub{{Kind: "foo", APIVersion: "bar"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := containsStub(tt.data)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Equal(t, tt.want, got)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
+			got := containsStub(tt.data)
+			assert.Equal(t, tt.want, got)
+
 		})
 	}
 }

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -135,51 +135,64 @@ func Test_yamlToStub(t *testing.T) {
 
 func Test_containsStub(t *testing.T) {
 	tests := []struct {
-		name string
-		data []byte
-		want []*Stub
+		name    string
+		data    []byte
+		want    []*Stub
+		wantErr bool
 	}{
 		{
-			name: "yaml not stub",
-			data: []byte("foo: bar"),
-			want: []*Stub{{}},
+			name:    "yaml not stub",
+			data:    []byte("foo: bar"),
+			want:    []*Stub{{}},
+			wantErr: false,
 		},
 		{
-			name: "not yaml",
-			data: []byte("*."),
-			want: nil,
+			name:    "not yaml",
+			data:    []byte("*."),
+			want:    nil,
+			wantErr: true,
 		},
 		{
-			name: "yaml is stub",
-			data: []byte("kind: foo\napiVersion: bar"),
-			want: []*Stub{{Kind: "foo", APIVersion: "bar"}},
+			name:    "yaml is stub",
+			data:    []byte("kind: foo\napiVersion: bar"),
+			want:    []*Stub{{Kind: "foo", APIVersion: "bar"}},
+			wantErr: false,
 		},
 		{
-			name: "json not stub",
-			data: []byte("{}"),
-			want: []*Stub{{}},
+			name:    "json not stub",
+			data:    []byte("{}"),
+			want:    []*Stub{{}},
+			wantErr: false,
 		},
 		{
-			name: "empty string",
-			data: []byte(""),
-			want: nil,
+			name:    "empty string",
+			data:    []byte(""),
+			want:    nil,
+			wantErr: false,
 		},
 		{
-			name: "no data",
-			data: []byte{},
-			want: nil,
+			name:    "no data",
+			data:    []byte{},
+			want:    nil,
+			wantErr: false,
 		},
 		{
-			name: "json is stub",
-			data: []byte(`{"kind": "foo", "apiVersion": "bar"}`),
-			want: []*Stub{{Kind: "foo", APIVersion: "bar"}},
+			name:    "json is stub",
+			data:    []byte(`{"kind": "foo", "apiVersion": "bar"}`),
+			want:    []*Stub{{Kind: "foo", APIVersion: "bar"}},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := containsStub(tt.data)
-			assert.Equal(t, tt.want, got)
-
+			got, err := containsStub(tt.data)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
 		})
 	}
 }
@@ -232,6 +245,12 @@ func Test_IsVersioned(t *testing.T) {
 			data:    []byte(`{"kind": "Deployment", "apiVersion": "extensions/v1beta1"}`),
 			want:    []*Output{{APIVersion: &testVersionDeployment}},
 			wantErr: false,
+		},
+		{
+			name:    "not yaml",
+			data:    []byte("*."),
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -117,9 +117,6 @@ func (dir *Dir) CheckForAPIVersion(file string) ([]*api.Output, error) {
 		return nil, err
 	}
 
-	if len(outputs) < 1 {
-		return outputs, nil
-	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -71,13 +71,18 @@ func (dir *Dir) FindVersions() error {
 // listFiles gets a list of all the files in the directory.
 func (dir *Dir) listFiles() error {
 	var files []string
-
-	if _, err := os.Stat(dir.RootPath); os.IsNotExist(err) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if _, err = os.Stat(dir.RootPath); os.IsNotExist(err) {
 		return fmt.Errorf("specified path does not exist")
 	}
-	err := filepath.Walk(dir.RootPath, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dir.RootPath, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
-			files = append(files, path)
+			fullPath := fmt.Sprintf("%s/%s", cwd, path)
+			klog.V(6).Infof("full path - %s", fullPath)
+			files = append(files, fullPath)
 		}
 		return nil
 	})

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -71,18 +71,13 @@ func (dir *Dir) FindVersions() error {
 // listFiles gets a list of all the files in the directory.
 func (dir *Dir) listFiles() error {
 	var files []string
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if _, err = os.Stat(dir.RootPath); os.IsNotExist(err) {
+
+	if _, err := os.Stat(dir.RootPath); os.IsNotExist(err) {
 		return fmt.Errorf("specified path does not exist")
 	}
-	err = filepath.Walk(dir.RootPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(dir.RootPath, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
-			fullPath := fmt.Sprintf("%s/%s", cwd, path)
-			klog.V(6).Infof("full path - %s", fullPath)
-			files = append(files, fullPath)
+			files = append(files, path)
 		}
 		return nil
 	})
@@ -120,6 +115,19 @@ func (dir *Dir) CheckForAPIVersion(file string) ([]*api.Output, error) {
 	outputs, err := dir.Instance.IsVersioned(data)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(outputs) < 1 {
+		return outputs, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	filePath := fmt.Sprintf("%s/%s", cwd, file)
+	for _, output := range outputs {
+		output.FilePath = filePath
 	}
 	return outputs, nil
 }

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -72,9 +72,9 @@ var testVersionDeployment = api.Version{
 	Component:      "k8s",
 }
 
-func newMockFinder() *Dir {
+func newMockFinder(path string) *Dir {
 	dir := &Dir{
-		RootPath: testPath,
+		RootPath: path,
 		Instance: &api.Instance{
 			TargetVersions: map[string]string{
 				"k8s":          "v1.16.0",
@@ -114,7 +114,7 @@ func TestNewFinder(t *testing.T) {
 		{
 			name: "one",
 			path: testPath,
-			want: newMockFinder(),
+			want: newMockFinder(testPath),
 		},
 		{
 			name: "cwd",
@@ -181,7 +181,7 @@ func TestDir_listFiles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := newMockFinder()
+			dir := newMockFinder(testPath)
 			dir.RootPath = tt.directory
 			err := dir.listFiles()
 			if tt.wantErr {
@@ -215,7 +215,7 @@ func Test_checkForAPIVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := newMockFinder()
+			dir := newMockFinder(testPath)
 			got, err := dir.CheckForAPIVersion(tt.file)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -243,7 +243,7 @@ func TestDir_scanFiles(t *testing.T) {
 			want:     deploymentExtensionsV1YamlFile,
 		},
 	}
-	dir := newMockFinder()
+	dir := newMockFinder(testPath)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir.FileList = tt.fileList
@@ -273,11 +273,17 @@ func TestDir_FindVersions(t *testing.T) {
 			path:    testPath,
 			want:    testOutput,
 		},
+		{
+			name:    "fail",
+			wantErr: true,
+			path:    "foo",
+			want:    testOutput,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := newMockFinder()
+			dir := newMockFinder(tt.path)
 			dir.Instance.Outputs = nil
 			err := dir.FindVersions()
 			if tt.wantErr {
@@ -285,7 +291,6 @@ func TestDir_FindVersions(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				patchFilePath(t, dir.Instance.Outputs)
-
 				assert.EqualValues(t, tt.want, dir.Instance.Outputs)
 			}
 		})

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -92,6 +92,18 @@ func newMockFinder() *Dir {
 	return dir
 }
 
+// patchFilePath exists because the filePath will be different
+// on every system. This asserts that the current working directory
+// is in the file path and then sets it to an empty string
+func patchFilePath(t *testing.T, outputs []*api.Output) {
+	cwd, _ := os.Getwd()
+	// Account for current working dir
+	for _, output := range outputs {
+		assert.Contains(t, output.FilePath, cwd)
+		output.FilePath = ""
+	}
+}
+
 func TestNewFinder(t *testing.T) {
 	wd, _ := os.Getwd()
 	tests := []struct {
@@ -209,6 +221,7 @@ func Test_checkForAPIVersion(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				patchFilePath(t, got)
 				assert.EqualValues(t, tt.want, got)
 			}
 		})
@@ -240,6 +253,7 @@ func TestDir_scanFiles(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.EqualValues(t, tt.fileList, dir.FileList)
+				patchFilePath(t, dir.Instance.Outputs)
 				assert.EqualValues(t, tt.want, dir.Instance.Outputs)
 			}
 		})
@@ -247,7 +261,6 @@ func TestDir_scanFiles(t *testing.T) {
 }
 
 func TestDir_FindVersions(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		wantErr bool
@@ -271,6 +284,8 @@ func TestDir_FindVersions(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				patchFilePath(t, dir.Instance.Outputs)
+
 				assert.EqualValues(t, tt.want, dir.Instance.Outputs)
 			}
 		})


### PR DESCRIPTION
This adds filepath to the output if it is known. It is not included by default in any of the tabular outputs, but adds it as a column option. 

Filepath will be in the json and yaml output as well

Fixes #97 

Additional non-related changes:

- I removed the error handling from the containsStub function. There was no possible way it could return an error.
- Removed an unnecessary check for nil in the UnMarshalVersions function.