### PR TITLE
feat: detection from kind: List

### DIFF
--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -246,6 +246,12 @@ func Test_IsVersioned(t *testing.T) {
 			want:    []*Output{{APIVersion: &testVersionDeployment}},
 			wantErr: false,
 		},
+		{
+			name:    "json list has version",
+			data:    []byte(`{"kind": "List", "apiVersion": "v1", "items":[{"kind": "Deployment", "apiVersion": "extensions/v1beta1"}]}`),
+			want:    []*Output{{APIVersion: &testVersionDeployment}},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This allow to pipe into pluto using `kubectl get deployments -o yaml | pluto detect -`. It was only allowing one resource at the time before that.