### PR TITLE
Update imports for major version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fairwindsops/pluto/pkg/api"
-	"github.com/fairwindsops/pluto/pkg/finder"
-	"github.com/fairwindsops/pluto/pkg/helm"
+	"github.com/fairwindsops/pluto/v3/pkg/api"
+	"github.com/fairwindsops/pluto/v3/pkg/finder"
+	"github.com/fairwindsops/pluto/v3/pkg/helm"
 	"github.com/rogpeppe/go-internal/semver"
 
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fairwindsops/pluto
+module github.com/fairwindsops/pluto/v3
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fairwindsops/pluto v1.1.0 h1:o5sfcW7hc6g09PpoKwA7M7/P+wrXi7tLIxAhwr3dENw=
+github.com/fairwindsops/pluto v1.1.0/go.mod h1:HKLQoH3JrKspDsvJfhWMXToqZJ/tY9cFEeyvk2cHjKs=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -670,6 +672,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+helm.sh/helm v2.16.5+incompatible/go.mod h1:0Xbc6ErzwWH9qC55X1+hE3ZwhM3atbhCm/NbFZw5i+4=
 helm.sh/helm v2.16.6+incompatible h1:bpHl8mnkfGRx3CL/kfolSVU99U7P71G8ynHlumMJVTE=
 helm.sh/helm v2.16.6+incompatible/go.mod h1:0Xbc6ErzwWH9qC55X1+hE3ZwhM3atbhCm/NbFZw5i+4=
 helm.sh/helm/v3 v3.1.2 h1:VpNzaNv2DX4aRnOCcV7v5Of+XT2SZrJ8iOQ25AGKOos=

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/fairwindsops/pluto/cmd"
+	"github.com/fairwindsops/pluto/v3/cmd"
 	"github.com/markbates/pkger"
 )
 

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/fairwindsops/pluto/pkg/api"
+	"github.com/fairwindsops/pluto/v3/pkg/api"
 )
 
 // Dir is the finder dirlication

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fairwindsops/pluto/pkg/api"
+	"github.com/fairwindsops/pluto/v3/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -24,7 +24,7 @@ import (
 	driverv3 "helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/klog"
 
-	"github.com/fairwindsops/pluto/pkg/api"
+	"github.com/fairwindsops/pluto/v3/pkg/api"
 )
 
 // Helm represents all current releases that we can find in the cluster

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -17,7 +17,7 @@ package helm
 import (
 	"testing"
 
-	"github.com/fairwindsops/pluto/pkg/api"
+	"github.com/fairwindsops/pluto/v3/pkg/api"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Outside projects can only import Pluto v1 right now because of the way Go Mod handles Semver. This will fix it so v3 is importable.