### PR TITLE
apiextensions.k8s.io/v1beta1 and admissionregistration.k8s.io/v1beta1  deprecated in 1.22

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -98,13 +98,13 @@ deprecated-versions:
   - version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     deprecated-in: v1.16.0
-    removed-in: v1.19.0
+    removed-in: v1.22.0
     replacement-api: apiextensions.k8s.io/v1
     component: k8s
   - version: admissionregistration.k8s.io/v1beta1
     kind: MutatingWebhookConfiguration
     deprecated-in: v1.16.0
-    removed-in: v1.19.0
+    removed-in: v1.22.0
     replacement-api: admissionregistration.k8s.io/v1
     component: k8s
   - version: rbac.authorization.k8s.io/v1alpha1


### PR DESCRIPTION
Fixes #147 