### PR TITLE
docs: Add missing asdf local pluto

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,7 @@ We have an [asdf](https://asdf-vm.com/#/) plugin [here](https://github.com/Fairw
 asdf plugin-add pluto
 asdf list-all pluto
 asdf install pluto <latest version>
+asdf local pluto <latest version>
 ```
 
 ## Binary


### PR DESCRIPTION
Add `asdf local pluto` which is missing in the installation.

Otherwise, it returns the following:
```
No version set for command pluto
Consider adding one of the following versions in your config file at
pluto 4.0.4
```