### PR TITLE
Link to Kubernetes deprecated API list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   </a>
 </div>
 
-Pluto is a utility to help users find deprecated Kubernetes apiVersions in their code repositories and their helm releases.
+Pluto is a utility to help users find [deprecated Kubernetes apiVersions](https://k8s.io/docs/reference/using-api/deprecation-guide/) in their code repositories and their helm releases.
 
 **Want to learn more?** Reach out on [the Slack channel](https://fairwindscommunity.slack.com/messages/pluto) ([request invite](https://join.slack.com/t/fairwindscommunity/shared_invite/zt-e3c6vj4l-3lIH6dvKqzWII5fSSFDi1g)), send an email to `opensource@fairwinds.com`, or join us for [office hours on Zoom](https://fairwindscommunity.slack.com/messages/office-hours)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
   </a>
 </div>
 
-Pluto is a utility to help users find deprecated Kubernetes apiVersions in their code repositories and their helm releases.
+Pluto is a utility to help users find [deprecated Kubernetes apiVersions](https://k8s.io/docs/reference/using-api/deprecation-guide/) in their code repositories and their helm releases.
 
 **Want to learn more?** Reach out on [the Slack channel](https://fairwindscommunity.slack.com/messages/pluto) ([request invite](https://join.slack.com/t/fairwindscommunity/shared_invite/zt-e3c6vj4l-3lIH6dvKqzWII5fSSFDi1g)), send an email to `opensource@fairwinds.com`, or join us for [office hours on Zoom](https://fairwindscommunity.slack.com/messages/office-hours)
 


### PR DESCRIPTION
Link from https://pluto.docs.fairwinds.com/ to the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) at https:\/\/k8s.io/docs/reference/using-api/deprecation-guide/