### PR TITLE
Adjust removed-in version for PriorityClass

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -86,7 +86,7 @@ deprecated-versions:
   - version: scheduling.k8s.io/v1beta1
     kind: PriorityClass
     deprecated-in: v1.14.0
-    removed-in: v1.17.0
+    removed-in: v1.22.0
     replacement-api: scheduling.k8s.io/v1
     component: k8s
   - version: scheduling.k8s.io/v1alpha1


### PR DESCRIPTION
According to the [official docs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#priorityclass-v122):

> The scheduling.k8s.io/v1beta1 API version of PriorityClass will no longer be served in v1.22

Adjusted `versions.yaml` file to match.