### PR TITLE
HPA v2beta2 deprecation should be in k8s 1.23

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -235,7 +235,7 @@ deprecated-versions:
     component: k8s
   - version: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
-    deprecated-in: v1.22.0
+    deprecated-in: v1.23.0
     removed-in: ""
     replacement-api: autoscaling/v1
     component: k8s


### PR DESCRIPTION
Fixes #212