### PR TITLE
make sure proper tag is used on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
+      - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
   snapshot:
     working_directory: /go/src/github.com/fairwindsops/pluto


### PR DESCRIPTION
Similar to a change made in goldilocks, making sure goreleaser picks the proper tag in the case there are multiple tags for a given git commit hash.