### PR TITLE
`autoscaling/v2beta2` replacement should be `autoscaling/v2`

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -237,13 +237,13 @@ deprecated-versions:
     kind: HorizontalPodAutoscaler
     deprecated-in: v1.23.0
     removed-in: ""
-    replacement-api: autoscaling/v1
+    replacement-api: autoscaling/v2
     component: k8s
   - version: autoscaling/v2beta2
     kind: HorizontalPodAutoscalerList
     deprecated-in: v1.22.0
     removed-in: ""
-    replacement-api: autoscaling/v1
+    replacement-api: autoscaling/v2
     component: k8s
   - version: batch/v1beta1
     kind: CronJob


### PR DESCRIPTION
This PR fixes #280

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Bugfix on replacement API for `autoscaling/v2beta2`

### What changes did you make?
`autoscaling/v1` -> `autoscaling/v2`

### What alternative solution should we consider, if any?
None