### PR TITLE
Add PodSecurityPolicy removal in kube v1.25

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -71,6 +71,12 @@ deprecated-versions:
     removed-in: v1.16.0
     replacement-api: policy/v1beta1
     component: k8s
+  - version: policy/v1beta1
+    kind: PodSecurityPolicy
+    deprecated-in: v1.21.0
+    removed-in: v1.25.0
+    replacement-api: ""
+    component: k8s
   - version: extensions/v1beta1
     kind: ReplicaSet
     deprecated-in: ""


### PR DESCRIPTION
This PR fixes #286

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add removal of PodSecurityPolicy to versions.yaml
### What changes did you make?
See diff

### What alternative solution should we consider, if any?
N/A