### PR TITLE
Enable orb to use environment variables from context

### DIFF
--- a/orb/commands/configure_env.yml
+++ b/orb/commands/configure_env.yml
@@ -1,0 +1,29 @@
+description: Configures pluto environment variables.
+parameters:
+  executor:
+    description: The name of custom executor to use. Only recommended for development.
+    type: executor
+    default: default
+  ignore-deprecations:
+    type: boolean
+    default: false
+    description: Exit Code 3 is ignored, useful if you do not want the job to fail if deprecated APIs are detected.
+  ignore-removals:
+    type: boolean
+    default: false
+    description: Exit Code 3 is ignored, useful if you do not want the job to fail if removed APIs are detected.
+  target-versions:
+    description: You can target the Kubernetes version you are concerned with. If blank defaults to latest.
+    type: string
+    default: ""
+steps:
+  - run:
+      name: configure Pluto env vars
+      command: |
+        #!/bin/bash
+
+        set -e
+
+        echo PLUTO_IGNORE_DEPRECATIONS=<<parameters.ignore-deprecations>> >> $BASH_ENV
+        echo PLUTO_IGNORE_REMOVALS=<<parameters.ignore-removals>> >> $BASH_ENV
+        echo PLUTO_TARGET_VERSIONS=<<parameters.target-versions>> >> $BASH_ENV

--- a/orb/commands/detect.yml
+++ b/orb/commands/detect.yml
@@ -8,24 +8,9 @@ parameters:
     description: The name of custom executor to use. Only recommended for development.
     type: executor
     default: default
-  ignore-deprecations:
-    type: boolean
-    default: false
-    description: Exit Code 3 is ignored, useful if you do not want the job to fail if deprecated APIs are detected.
-  ignore-removals:
-    type: boolean
-    default: false
-    description: Exit Code 3 is ignored, useful if you do not want the job to fail if removed APIs are detected.
-  target-versions:
-    description: You can target the Kubernetes version you are concerned with. If blank defaults to latest.
-    type: string
-    default: ""
 steps:
   - run:
       name: Pluto detect
       environment:
         PLUTO_FILE: <<parameters.file>>
-        PLUTO_IGNORE_DEPRECATIONS: <<parameters.ignore-deprecations>>
-        PLUTO_IGNORE_REMOVALS: <<parameters.ignore-removals>>
-        PLUTO_TARGET_VERSIONS: <<parameters.target-versions>>
       command: <<include(scripts/detect.sh)>>

--- a/orb/commands/detect.yml
+++ b/orb/commands/detect.yml
@@ -10,16 +10,16 @@ parameters:
     default: default
   ignore-deprecations:
     type: boolean
-    default: false
+    default: "${PLUTO_IGNORE_DEPRECATIONS:=false}"
     description: Exit Code 3 is ignored, useful if you do not want the job to fail if deprecated APIs are detected.
   ignore-removals:
     type: boolean
-    default: false
+    default: "${PLUTO_IGNORE_REMOVALS:=false}"
     description: Exit Code 3 is ignored, useful if you do not want the job to fail if removed APIs are detected.
   target-versions:
     description: You can target the Kubernetes version you are concerned with. If blank defaults to latest.
     type: string
-    default: ""
+    default: "$PLUTO_TARGET_VERSIONS"
 steps:
   - run:
       name: Pluto detect

--- a/orb/commands/detect.yml
+++ b/orb/commands/detect.yml
@@ -10,16 +10,16 @@ parameters:
     default: default
   ignore-deprecations:
     type: boolean
-    default: "${PLUTO_IGNORE_DEPRECATIONS:=false}"
+    default: false
     description: Exit Code 3 is ignored, useful if you do not want the job to fail if deprecated APIs are detected.
   ignore-removals:
     type: boolean
-    default: "${PLUTO_IGNORE_REMOVALS:=false}"
+    default: false
     description: Exit Code 3 is ignored, useful if you do not want the job to fail if removed APIs are detected.
   target-versions:
     description: You can target the Kubernetes version you are concerned with. If blank defaults to latest.
     type: string
-    default: "$PLUTO_TARGET_VERSIONS"
+    default: ""
 steps:
   - run:
       name: Pluto detect

--- a/orb/commands/detect_files.yml
+++ b/orb/commands/detect_files.yml
@@ -8,24 +8,9 @@ parameters:
     description: The name of custom executor to use. Only recommended for development.
     type: executor
     default: default
-  ignore-deprecations:
-    type: boolean
-    default: false
-    description: Exit Code 3 is ignored, useful if you do not want the job to fail if deprecated APIs are detected.
-  ignore-removals:
-    type: boolean
-    default: false
-    description: Exit Code 3 is ignored, useful if you do not want the job to fail if removed APIs are detected.
-  target-versions:
-    description: You can target the Kubernetes version you are concerned with. If blank defaults to latest.
-    type: string
-    default: ""
 steps:
   - run:
       name: Pluto detect-files
       environment:
         PLUTO_DIRECTORY: <<parameters.directory>>
-        PLUTO_IGNORE_DEPRECATIONS: <<parameters.ignore-deprecations>>
-        PLUTO_IGNORE_REMOVALS: <<parameters.ignore-removals>>
-        PLUTO_TARGET_VERSIONS: <<parameters.target-versions>>
       command: <<include(scripts/detect_files.sh)>>

--- a/orb/examples/detect.yml
+++ b/orb/examples/detect.yml
@@ -11,4 +11,4 @@ usage:
             file: ./K8s/Descriptors/ingress.yml
             ignore-deprecations: true
             ignore-removals: false
-            target-versions: v1.21
+            target-versions: "k8s=v1.21"

--- a/orb/examples/detect_files.yml
+++ b/orb/examples/detect_files.yml
@@ -11,4 +11,4 @@ usage:
             directory: ./K8s/Descriptors
             ignore-deprecations: true
             ignore-removals: false
-            target-versions: v1.21
+            target-versions: "k8s=v1.21"

--- a/orb/jobs/detect.yml
+++ b/orb/jobs/detect.yml
@@ -13,6 +13,10 @@ parameters:
     description: The file to scan. Required.
     type: string
     default: ""
+  use-external-context:
+    type: boolean
+    default: false
+    description: If this is true, then the configure_env step will be skipped.
   ignore-deprecations:
     type: boolean
     default: false
@@ -37,8 +41,11 @@ steps:
         - checkout
   - install:
       version: <<parameters.version>>
-  - detect:
-      file: <<parameters.file>>
+  - configure_env:
+      when:
+        not: << parameters.use-external-context >>
       ignore-deprecations: <<parameters.ignore-deprecations>>
       ignore-removals: <<parameters.ignore-removals>>
       target-versions: <<parameters.target-versions>>
+  - detect:
+      file: <<parameters.file>>

--- a/orb/jobs/detect.yml
+++ b/orb/jobs/detect.yml
@@ -41,11 +41,13 @@ steps:
         - checkout
   - install:
       version: <<parameters.version>>
-  - configure_env:
-      when:
+  - when:
+      condition:
         not: << parameters.use-external-context >>
-      ignore-deprecations: <<parameters.ignore-deprecations>>
-      ignore-removals: <<parameters.ignore-removals>>
-      target-versions: <<parameters.target-versions>>
+      steps:
+        - configure_env:
+            ignore-deprecations: << parameters.ignore-deprecations >>
+            ignore-removals: << parameters.ignore-removals >>
+            target-versions: << parameters.target-versions >>
   - detect:
       file: <<parameters.file>>

--- a/orb/jobs/detect_files.yml
+++ b/orb/jobs/detect_files.yml
@@ -13,6 +13,10 @@ parameters:
     description: The name of custom executor to use. Only recommended for development.
     type: executor
     default: default
+  use-external-context:
+    type: boolean
+    default: false
+    description: If this is true, then the configure_env step will be skipped.
   ignore-deprecations:
     type: boolean
     default: false
@@ -37,8 +41,13 @@ steps:
         - checkout
   - install:
       version: <<parameters.version>>
+  - when:
+      condition:
+        not: << parameters.use-external-context >>
+      steps:
+        - configure_env:
+            ignore-deprecations: << parameters.ignore-deprecations >>
+            ignore-removals: << parameters.ignore-removals >>
+            target-versions: << parameters.target-versions >>
   - detect_files:
       directory: <<parameters.directory>>
-      ignore-deprecations: <<parameters.ignore-deprecations>>
-      ignore-removals: <<parameters.ignore-removals>>
-      target-versions: <<parameters.target-versions>>

--- a/orb/scripts/detect.sh
+++ b/orb/scripts/detect.sh
@@ -6,19 +6,4 @@ if [[ -z "${PLUTO_FILE}" ]]; then
     exit 1
 fi
 
-if [[ "${PLUTO_IGNORE_DEPRECATIONS}" = true ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --ignore-deprecations"
-fi
-
-if [[ "${PLUTO_IGNORE_REMOVALS}" = true ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --ignore-removals"
-fi
-
-if [[ -n "${PLUTO_TARGET_VERSIONS}" ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --target-versions k8s=${PLUTO_TARGET_VERSIONS}"
-fi
-
-export PLUTO_ARGS
-export PLUTO_FILE_PATH
-
-pluto detect $PLUTO_FILE $PLUTO_ARGS
+pluto detect "$PLUTO_FILE"

--- a/orb/scripts/detect_files.sh
+++ b/orb/scripts/detect_files.sh
@@ -5,18 +5,6 @@ if [[ -n "${PLUTO_DIRECTORY}" ]]; then
     PLUTO_ARGS="$PLUTO_ARGS --directory ${PLUTO_DIRECTORY}"
 fi
 
-if [[ "${PLUTO_IGNORE_DEPRECATIONS}" = true ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --ignore-deprecations"
-fi
-
-if [[ "${PLUTO_IGNORE_REMOVALS}" = true ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --ignore-removals"
-fi
-
-if [[ -n "${PLUTO_TARGET_VERSIONS}" ]]; then
-    PLUTO_ARGS="$PLUTO_ARGS --target-versions k8s=${PLUTO_TARGET_VERSIONS}"
-fi
-
 export PLUTO_ARGS
 
-pluto detect-files $PLUTO_ARGS
+pluto detect-files "$PLUTO_ARGS"


### PR DESCRIPTION
This PR fixes #285

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow disabling the input parameters for configuration so that circle context can be used.

### What changes did you make?
Added a configure_env command, and plumbed that into the jobs. This makes it so that config is always done via env vars, but the source of those vars can change.