### PR TITLE
[WIP] Update Go module path with `/v5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fairwindsops/pluto/v3
+module github.com/fairwindsops/pluto/v5
 
 go 1.17
 


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow versions 5.X of the Pluto packages to be imported. THIs has not been possible since version 4.x+.

### What changes did you make?
I updated the `go.mod` to use the `/v5` suffix to match the current major package version Git tags.

GO modules ref: https://go.dev/ref/mod#versions
