### PR TITLE
fix: preserve ordering of custom columns

### DIFF
--- a/e2e/tests/00_static_files.yaml
+++ b/e2e/tests/00_static_files.yaml
@@ -52,8 +52,8 @@ testcases:
   - script: pluto detect-files -d assets/ -o custom --columns "NAME,NAMESPACE,VERSION,KIND,DEPRECATED,DEPRECATED IN,component"
     assertions:
     - result.code ShouldEqual 3
-    - result.systemout ShouldContainSubstring "NAME        NAMESPACE   KIND         VERSION              DEPRECATED   DEPRECATED IN   COMPONENT"
-    - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   Deployment   extensions/v1beta1   true         v1.9.0          k8s"
+    - result.systemout ShouldContainSubstring "NAME        NAMESPACE   VERSION              KIND         DEPRECATED   DEPRECATED IN   COMPONENT"
+    - result.systemout ShouldContainSubstring "utilities   <UNKNOWN>   extensions/v1beta1   Deployment   true         v1.9.0          k8s"
 
 - name: static files show file path
   steps:

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -161,8 +161,8 @@ func (instance *Instance) wideColumns() columnList {
 // customColumns returns a custom list of columns based on names
 func (instance *Instance) customColumns() columnList {
 	var outputColumns = make(map[int]column)
-	for _, d := range instance.CustomColumns {
-		for i, c := range possibleColumns {
+	for i, d := range instance.CustomColumns {
+		for _, c := range possibleColumns {
 			if d == c.header() {
 				outputColumns[i] = c
 			}

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -167,9 +167,9 @@ func ExampleInstance_DisplayOutput_custom() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN-- COMPONENT-- FILEPATH------
-	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- foo-------- path-to-file--
-	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- foo-------- <UNKNOWN>-----
+	// NAMESPACE-------- NAME----------- DEPRECATED IN-- DEPRECATED-- REPLACEMENT-- VERSION------------- KIND-------- COMPONENT-- FILEPATH------
+	// pluto-namespace-- some name one-- v1.9.0--------- true-------- apps/v1------ extensions/v1beta1-- Deployment-- foo-------- path-to-file--
+	// <UNKNOWN>-------- some name two-- v1.9.0--------- true-------- apps/v1------ extensions/v1beta1-- Deployment-- foo-------- <UNKNOWN>-----
 }
 
 func ExampleInstance_DisplayOutput_markdown() {
@@ -209,10 +209,10 @@ func ExampleInstance_DisplayOutput_markdown_customcolumns() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// |     NAME      |    NAMESPACE    |    KIND    |      VERSION       | REPLACEMENT | DEPRECATED | DEPRECATED IN | COMPONENT |   FILEPATH   |
-	// |---------------|-----------------|------------|--------------------|-------------|------------|---------------|-----------|--------------|
-	// | some name one | pluto-namespace | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | foo       | path-to-file |
-	// | some name two | <UNKNOWN>       | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | foo       | <UNKNOWN>    |
+	// |    NAMESPACE    |     NAME      | DEPRECATED IN | DEPRECATED | REPLACEMENT |      VERSION       |    KIND    | COMPONENT |   FILEPATH   |
+	// |-----------------|---------------|---------------|------------|-------------|--------------------|------------|-----------|--------------|
+	// | pluto-namespace | some name one | v1.9.0        | true       | apps/v1     | extensions/v1beta1 | Deployment | foo       | path-to-file |
+	// | <UNKNOWN>       | some name two | v1.9.0        | true       | apps/v1     | extensions/v1beta1 | Deployment | foo       | <UNKNOWN>    |
 }
 
 func ExampleInstance_DisplayOutput_json() {
@@ -311,9 +311,9 @@ func ExampleInstance_DisplayOutput_csv_customcolumns() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME,NAMESPACE,KIND,VERSION,REPLACEMENT,DEPRECATED,DEPRECATED IN,COMPONENT,FILEPATH
-	// some name one,pluto-namespace,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,foo,path-to-file
-	// some name two,<UNKNOWN>,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,foo,<UNKNOWN>
+	// NAMESPACE,NAME,DEPRECATED IN,DEPRECATED,REPLACEMENT,VERSION,KIND,COMPONENT,FILEPATH
+	// pluto-namespace,some name one,v1.9.0,true,apps/v1,extensions/v1beta1,Deployment,foo,path-to-file
+	// <UNKNOWN>,some name two,v1.9.0,true,apps/v1,extensions/v1beta1,Deployment,foo,<UNKNOWN>
 }
 
 func ExampleInstance_DisplayOutput_noOutput() {


### PR DESCRIPTION
Fixes https://github.com/FairwindsOps/pluto/issues/409
Replaces https://github.com/FairwindsOps/pluto/issues/408

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This PR fixes the ordering of custom columns.

### What changes did you make?
Iterate and append columns using user provided custom columns index instead of available columns index.
