### PR TITLE
Fixed a linter error causing lack of compilation in Go 1.19

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -195,7 +195,7 @@ var rootCmd = &cobra.Command{
 		var deprecatedVersionList []api.Version
 		if additionalVersionsFile != "" {
 			klog.V(2).Infof("looking for versions file: %s", additionalVersionsFile)
-			data, err := ioutil.ReadFile(additionalVersionsFile)
+			data, err := os.ReadFile(additionalVersionsFile)
 			if err != nil {
 				return err
 			}
@@ -349,7 +349,7 @@ var detectCmd = &cobra.Command{
 
 		if args[0] == "-" {
 			//stdin
-			fileData, err := ioutil.ReadAll(os.Stdin)
+			fileData, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				fmt.Println("Error reading stdin:", err)
 				os.Exit(1)

--- a/pkg/finder/finder.go
+++ b/pkg/finder/finder.go
@@ -30,7 +30,6 @@ package finder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -122,7 +121,7 @@ func (dir *Dir) scanFiles() error {
 // it is an api-versioned Kubernetes object.
 // Returns the File object if it is.
 func (dir *Dir) CheckForAPIVersion(file string) ([]*api.Output, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed a linter error causing build to fail in Go 1.19 by removing deprecated io/ioutil functions and replacing them with their Go 1.16 counterparts.


This PR fixes #438

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To allow compilation using Go 1.19, by replacing deprecated Go functions with their counterparts.

### What changes did you make?
I changed "io/ioutil".ReadFile to os.ReadFile and "io/ioutil".ReadAll to os.ReadAll for all occurrences.

### What alternative solution should we consider, if any?
If backwards compatibility with Go versions prior to 1.16 is important for this project, a solution which vendors the dependency with version-specific calls should be favoured.
