### PR TITLE
fix: add removed-in to storage.k8s.io/v1beta1.CSIStorageCapacity

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -284,6 +284,7 @@ deprecated-versions:
   - version: storage.k8s.io/v1beta1
     kind: CSIStorageCapacity
     deprecated-in: v1.24.0
+    removed-in: v1.27.0
     replacement-api: storage.k8s.io/v1
     component: k8s
   - version: storage.k8s.io/v1beta1


### PR DESCRIPTION

This PR fixes #436 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Add the following deprecated.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#csistoragecapacity-v127

### What changes did you make?

I have not used this resource, but have changed values.yaml because I thought the Issue was correct.

### What alternative solution should we consider, if any?
