### PR TITLE
add replacement-available-in

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,23 +48,24 @@ import (
 )
 
 var (
-	version                string
-	versionCommit          string
-	versionFileData        []byte
-	additionalVersionsFile string
-	directory              string
-	outputFormat           string
-	ignoreDeprecations     bool
-	ignoreRemovals         bool
-	namespace              string
-	apiInstance            *api.Instance
-	targetVersions         map[string]string
-	customColumns          []string
-	componentsFromUser     []string
-	onlyShowRemoved        bool
-	kubeContext            string
-	noHeaders              bool
-	exitCode               int
+	version                       string
+	versionCommit                 string
+	versionFileData               []byte
+	additionalVersionsFile        string
+	directory                     string
+	outputFormat                  string
+	ignoreDeprecations            bool
+	ignoreRemovals                bool
+	ignoreUnavailableReplacements bool
+	namespace                     string
+	apiInstance                   *api.Instance
+	targetVersions                map[string]string
+	customColumns                 []string
+	componentsFromUser            []string
+	onlyShowRemoved               bool
+	kubeContext                   string
+	noHeaders                     bool
+	exitCode                      int
 )
 
 const (
@@ -84,6 +85,7 @@ var outputOptions = []string{
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&ignoreDeprecations, "ignore-deprecations", false, "Ignore the default behavior to exit 2 if deprecated apiVersions are found.")
 	rootCmd.PersistentFlags().BoolVar(&ignoreRemovals, "ignore-removals", false, "Ignore the default behavior to exit 3 if removed apiVersions are found.")
+	rootCmd.PersistentFlags().BoolVar(&ignoreUnavailableReplacements, "ignore-unavailable-replacements", false, "Ignore the default behavior to exit 2 if deprecated but unavailable apiVersions are found.")
 	rootCmd.PersistentFlags().BoolVarP(&onlyShowRemoved, "only-show-removed", "r", false, "Only display the apiVersions that have been removed in the target version.")
 	rootCmd.PersistentFlags().BoolVarP(&noHeaders, "no-headers", "H", false, "When using the default or custom-column output format, don't print headers (default print headers).")
 	rootCmd.PersistentFlags().StringVarP(&additionalVersionsFile, "additional-versions", "f", "", "Additional deprecated versions file to add to the list. Cannot contain any existing versions")
@@ -268,15 +270,16 @@ var rootCmd = &cobra.Command{
 
 		// this apiInstance will be used by all detection methods
 		apiInstance = &api.Instance{
-			TargetVersions:     targetVersions,
-			OutputFormat:       outputFormat,
-			CustomColumns:      customColumns,
-			IgnoreDeprecations: ignoreDeprecations,
-			IgnoreRemovals:     ignoreRemovals,
-			OnlyShowRemoved:    onlyShowRemoved,
-			NoHeaders:          noHeaders,
-			DeprecatedVersions: deprecatedVersionList,
-			Components:         componentList,
+			TargetVersions:                targetVersions,
+			OutputFormat:                  outputFormat,
+			CustomColumns:                 customColumns,
+			IgnoreDeprecations:            ignoreDeprecations,
+			IgnoreRemovals:                ignoreRemovals,
+			IgnoreUnavailableReplacements: ignoreUnavailableReplacements,
+			OnlyShowRemoved:               onlyShowRemoved,
+			NoHeaders:                     noHeaders,
+			DeprecatedVersions:            deprecatedVersionList,
+			Components:                    componentList,
 		}
 
 		return nil

--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -24,7 +24,7 @@ type column interface {
 
 type columnList map[int]column
 
-//PossibleColumnNames is the list of implmented columns
+// PossibleColumnNames is the list of implmented columns
 var PossibleColumnNames = []string{
 	"NAME",
 	"FILEPATH",
@@ -37,6 +37,8 @@ var PossibleColumnNames = []string{
 	"REMOVED",
 	"REMOVED IN",
 	"COMPONENT",
+	"AVAILABLE",
+	"AVAILABLE IN",
 }
 
 var possibleColumns = []column{
@@ -129,6 +131,20 @@ type component struct{}
 func (c component) header() string              { return "COMPONENT" }
 func (c component) value(output *Output) string { return output.APIVersion.Component }
 
+// available is the output for the boolean ReplacementAvailable
+type available struct{}
+
+func (a available) header() string { return "AVAILABLE" }
+func (a available) value(output *Output) string {
+	return fmt.Sprintf("%t", output.ReplacementAvailable)
+}
+
+// availableIn is the string value of when an output was ReplacementAvailableIn
+type availableIn struct{}
+
+func (ai availableIn) header() string              { return "AVAILABLE IN" }
+func (ai availableIn) value(output *Output) string { return output.APIVersion.ReplacementAvailableIn }
+
 // normalColumns returns the list of columns for -onormal
 func (instance *Instance) normalColumns() columnList {
 	columnList := columnList{
@@ -138,6 +154,7 @@ func (instance *Instance) normalColumns() columnList {
 		3: new(replacement),
 		4: new(removed),
 		5: new(deprecated),
+		6: new(available),
 	}
 	return columnList
 }
@@ -145,15 +162,17 @@ func (instance *Instance) normalColumns() columnList {
 // wideColumns returns the list of columns for -owide
 func (instance *Instance) wideColumns() columnList {
 	columnList := columnList{
-		0: new(name),
-		1: new(namespace),
-		2: new(kind),
-		3: new(version),
-		4: new(replacement),
-		5: new(deprecated),
-		6: new(deprecatedIn),
-		7: new(removed),
-		8: new(removedIn),
+		0:  new(name),
+		1:  new(namespace),
+		2:  new(kind),
+		3:  new(version),
+		4:  new(replacement),
+		5:  new(deprecated),
+		6:  new(deprecatedIn),
+		7:  new(removed),
+		8:  new(removedIn),
+		9:  new(available),
+		10: new(availableIn),
 	}
 	return columnList
 }

--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -45,22 +45,25 @@ type Output struct {
 	Deprecated bool `json:"deprecated" yaml:"deprecated"`
 	// Removed is a boolean indicating whether or not the version has been removed
 	Removed bool `json:"removed" yaml:"removed"`
+	// ReplacementAvailable is a boolean indicating whether or not the replacement is available
+	ReplacementAvailable bool `json:"replacementAvailable" yaml:"replacementAvailable"`
 	// CustomColumns is a list of column headers to be displayed with -ocustom or -omarkdown
 	CustomColumns []string `json:"-" yaml:"-"`
 }
 
 // Instance is an instance of the API. This holds configuration for a "run" of Pluto
 type Instance struct {
-	Outputs            []*Output         `json:"items,omitempty" yaml:"items,omitempty"`
-	IgnoreDeprecations bool              `json:"-" yaml:"-"`
-	IgnoreRemovals     bool              `json:"-" yaml:"-"`
-	OnlyShowRemoved    bool              `json:"-" yaml:"-"`
-	NoHeaders          bool              `json:"-" yaml:"-"`
-	OutputFormat       string            `json:"-" yaml:"-"`
-	TargetVersions     map[string]string `json:"target-versions,omitempty" yaml:"target-versions,omitempty"`
-	DeprecatedVersions []Version         `json:"-" yaml:"-"`
-	CustomColumns      []string          `json:"-" yaml:"-"`
-	Components         []string          `json:"-" yaml:"-"`
+	Outputs                       []*Output         `json:"items,omitempty" yaml:"items,omitempty"`
+	IgnoreDeprecations            bool              `json:"-" yaml:"-"`
+	IgnoreRemovals                bool              `json:"-" yaml:"-"`
+	IgnoreUnavailableReplacements bool              `json:"-" yaml:"-"`
+	OnlyShowRemoved               bool              `json:"-" yaml:"-"`
+	NoHeaders                     bool              `json:"-" yaml:"-"`
+	OutputFormat                  string            `json:"-" yaml:"-"`
+	TargetVersions                map[string]string `json:"target-versions,omitempty" yaml:"target-versions,omitempty"`
+	DeprecatedVersions            []Version         `json:"-" yaml:"-"`
+	CustomColumns                 []string          `json:"-" yaml:"-"`
+	Components                    []string          `json:"-" yaml:"-"`
 }
 
 // DisplayOutput prints the output based on desired variables
@@ -155,6 +158,7 @@ func (instance *Instance) FilterOutput() {
 	for _, output := range instance.Outputs {
 		output.Deprecated = output.APIVersion.isDeprecatedIn(instance.TargetVersions)
 		output.Removed = output.APIVersion.isRemovedIn(instance.TargetVersions)
+		output.ReplacementAvailable = output.APIVersion.isReplacementAvailableIn(instance.TargetVersions)
 		switch instance.OnlyShowRemoved {
 		case false:
 			if output.Deprecated || output.Removed {
@@ -307,7 +311,9 @@ func (instance *Instance) GetReturnCode() int {
 			removals = removals + 1
 		}
 		if output.APIVersion.isDeprecatedIn(instance.TargetVersions) {
-			deprecations = deprecations + 1
+			if output.APIVersion.isReplacementAvailableIn(instance.TargetVersions) || !instance.IgnoreUnavailableReplacements {
+				deprecations = deprecations + 1
+			}
 		}
 	}
 	if deprecations > 0 && !instance.IgnoreDeprecations {

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -39,35 +39,38 @@ var testOutput1 = &Output{
 	Namespace: "pluto-namespace",
 	FilePath:  "path-to-file",
 	APIVersion: &Version{
-		Name:           "extensions/v1beta1",
-		Kind:           "Deployment",
-		DeprecatedIn:   "v1.9.0",
-		RemovedIn:      "v1.16.0",
-		ReplacementAPI: "apps/v1",
-		Component:      "foo",
+		Name:                   "extensions/v1beta1",
+		Kind:                   "Deployment",
+		DeprecatedIn:           "v1.9.0",
+		RemovedIn:              "v1.16.0",
+		ReplacementAPI:         "apps/v1",
+		ReplacementAvailableIn: "v1.10.0",
+		Component:              "foo",
 	},
 }
 var testOutput2 = &Output{
 	Name: "some name two",
 	APIVersion: &Version{
-		Name:           "extensions/v1beta1",
-		Kind:           "Deployment",
-		DeprecatedIn:   "v1.9.0",
-		RemovedIn:      "v1.16.0",
-		ReplacementAPI: "apps/v1",
-		Component:      "foo",
+		Name:                   "extensions/v1beta1",
+		Kind:                   "Deployment",
+		DeprecatedIn:           "v1.9.0",
+		RemovedIn:              "v1.16.0",
+		ReplacementAPI:         "apps/v1",
+		ReplacementAvailableIn: "v1.10.0",
+		Component:              "foo",
 	},
 }
 
 var testOutputNoOutput = &Output{
 	Name: "not a deprecated object",
 	APIVersion: &Version{
-		Name:           "apps/v1",
-		Kind:           "Deployment",
-		DeprecatedIn:   "",
-		RemovedIn:      "",
-		ReplacementAPI: "",
-		Component:      "foo",
+		Name:                   "apps/v1",
+		Kind:                   "Deployment",
+		DeprecatedIn:           "",
+		RemovedIn:              "",
+		ReplacementAPI:         "",
+		ReplacementAvailableIn: "",
+		Component:              "foo",
 	},
 }
 
@@ -103,10 +106,10 @@ func ExampleInstance_DisplayOutput_normal() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME-------------------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED--
-	// some name one----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true--------
-	// some name two----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true--------
-	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true--------
+	// NAME-------------------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED-- AVAILABLE--
+	// some name one----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true-------
+	// some name two----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true-------
+	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true-------- true-------
 }
 
 func ExampleInstance_DisplayOutput_onlyShowRemoved() {
@@ -126,9 +129,9 @@ func ExampleInstance_DisplayOutput_onlyShowRemoved() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME----------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED--
-	// some name one-- Deployment-- extensions/v1beta1-- apps/v1------ true----- true--------
-	// some name two-- Deployment-- extensions/v1beta1-- apps/v1------ true----- true--------
+	// NAME----------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED-- AVAILABLE--
+	// some name one-- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true-------
+	// some name two-- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true-------
 }
 
 func ExampleInstance_DisplayOutput_wide() {
@@ -146,9 +149,9 @@ func ExampleInstance_DisplayOutput_wide() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN-- REMOVED-- REMOVED IN--
-	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- true----- v1.16.0-----
-	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- true----- v1.16.0-----
+	// NAME----------- NAMESPACE-------- KIND-------- VERSION------------- REPLACEMENT-- DEPRECATED-- DEPRECATED IN-- REMOVED-- REMOVED IN-- AVAILABLE-- AVAILABLE IN--
+	// some name one-- pluto-namespace-- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- true----- v1.16.0----- true------- v1.10.0-------
+	// some name two-- <UNKNOWN>-------- Deployment-- extensions/v1beta1-- apps/v1------ true-------- v1.9.0--------- true----- v1.16.0----- true------- v1.10.0-------
 }
 
 func ExampleInstance_DisplayOutput_custom() {
@@ -187,10 +190,10 @@ func ExampleInstance_DisplayOutput_markdown() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// |     NAME      |    NAMESPACE    |    KIND    |      VERSION       | REPLACEMENT | DEPRECATED | DEPRECATED IN | REMOVED | REMOVED IN |
-	// |---------------|-----------------|------------|--------------------|-------------|------------|---------------|---------|------------|
-	// | some name one | pluto-namespace | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | true    | v1.16.0    |
-	// | some name two | <UNKNOWN>       | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | true    | v1.16.0    |
+	// |     NAME      |    NAMESPACE    |    KIND    |      VERSION       | REPLACEMENT | DEPRECATED | DEPRECATED IN | REMOVED | REMOVED IN | AVAILABLE | AVAILABLE IN |
+	// |---------------|-----------------|------------|--------------------|-------------|------------|---------------|---------|------------|-----------|--------------|
+	// | some name one | pluto-namespace | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | true    | v1.16.0    | true      | v1.10.0      |
+	// | some name two | <UNKNOWN>       | Deployment | extensions/v1beta1 | apps/v1     | true       | v1.9.0        | true    | v1.16.0    | true      | v1.10.0      |
 }
 
 func ExampleInstance_DisplayOutput_markdown_customcolumns() {
@@ -230,7 +233,7 @@ func ExampleInstance_DisplayOutput_json() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// {"items":[{"name":"some name one","filePath":"path-to-file","namespace":"pluto-namespace","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true},{"name":"some name two","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"foo"},"deprecated":true,"removed":true}],"target-versions":{"foo":"v1.16.0"}}
+	// {"items":[{"name":"some name one","filePath":"path-to-file","namespace":"pluto-namespace","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","replacement-available-in":"v1.10.0","component":"foo"},"deprecated":true,"removed":true,"replacementAvailable":true},{"name":"some name two","api":{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","replacement-available-in":"v1.10.0","component":"foo"},"deprecated":true,"removed":true,"replacementAvailable":true}],"target-versions":{"foo":"v1.16.0"}}
 }
 
 func ExampleInstance_DisplayOutput_yaml() {
@@ -258,9 +261,11 @@ func ExampleInstance_DisplayOutput_yaml() {
 	//         deprecated-in: v1.9.0
 	//         removed-in: v1.16.0
 	//         replacement-api: apps/v1
+	//         replacement-available-in: v1.10.0
 	//         component: foo
 	//       deprecated: true
 	//       removed: true
+	//       replacementAvailable: true
 	//     - name: some name two
 	//       api:
 	//         version: extensions/v1beta1
@@ -268,9 +273,11 @@ func ExampleInstance_DisplayOutput_yaml() {
 	//         deprecated-in: v1.9.0
 	//         removed-in: v1.16.0
 	//         replacement-api: apps/v1
+	//         replacement-available-in: v1.10.0
 	//         component: foo
 	//       deprecated: true
 	//       removed: true
+	//       replacementAvailable: true
 	// target-versions:
 	//     foo: v1.16.0
 }
@@ -290,9 +297,9 @@ func ExampleInstance_DisplayOutput_csv() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// NAME,NAMESPACE,KIND,VERSION,REPLACEMENT,DEPRECATED,DEPRECATED IN,REMOVED,REMOVED IN
-	// some name one,pluto-namespace,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0
-	// some name two,<UNKNOWN>,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0
+	// NAME,NAMESPACE,KIND,VERSION,REPLACEMENT,DEPRECATED,DEPRECATED IN,REMOVED,REMOVED IN,AVAILABLE,AVAILABLE IN
+	// some name one,pluto-namespace,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0,true,v1.10.0
+	// some name two,<UNKNOWN>,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0,true,v1.10.0
 }
 
 func ExampleInstance_DisplayOutput_csv_customcolumns() {
@@ -332,8 +339,8 @@ func ExampleInstance_DisplayOutput_csv_noHeaders() {
 	_ = instance.DisplayOutput()
 
 	// Output:
-	// some name one,pluto-namespace,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0
-	// some name two,<UNKNOWN>,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0
+	// some name one,pluto-namespace,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0,true,v1.10.0
+	// some name two,<UNKNOWN>,Deployment,extensions/v1beta1,apps/v1,true,v1.9.0,true,v1.16.0,true,v1.10.0
 }
 
 func ExampleInstance_DisplayOutput_noOutput() {
@@ -368,9 +375,10 @@ func ExampleInstance_DisplayOutput_zeroLength() {
 func TestGetReturnCode(t *testing.T) {
 
 	type args struct {
-		outputs            []*Output
-		ignoreDeprecations bool
-		ignoreRemovals     bool
+		outputs                      []*Output
+		ignoreDeprecations           bool
+		ignoreRemovals               bool
+		ignoreReplacementUnavailable bool
 	}
 	tests := []struct {
 		name string
@@ -420,6 +428,43 @@ func TestGetReturnCode(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "version is deprecated and replacement is unavailable",
+			args: args{
+				outputs: []*Output{
+					{
+						APIVersion: &Version{
+							DeprecatedIn:           "v1.16.0",
+							RemovedIn:              "v1.20.0",
+							ReplacementAvailableIn: "v1.17.0",
+							Component:              "foo",
+						},
+					},
+				},
+				ignoreDeprecations: false,
+				ignoreRemovals:     false,
+			},
+			want: 2,
+		},
+		{
+			name: "version is deprecated and replacement is unavailable but ignored",
+			args: args{
+				outputs: []*Output{
+					{
+						APIVersion: &Version{
+							DeprecatedIn:           "v1.16.0",
+							RemovedIn:              "v1.20.0",
+							ReplacementAvailableIn: "v1.17.0",
+							Component:              "foo",
+						},
+					},
+				},
+				ignoreDeprecations:           false,
+				ignoreRemovals:               false,
+				ignoreReplacementUnavailable: true,
+			},
+			want: 0,
+		},
+		{
 			name: "version is removed",
 			args: args{
 				outputs: []*Output{
@@ -443,9 +488,10 @@ func TestGetReturnCode(t *testing.T) {
 				TargetVersions: map[string]string{
 					"foo": "v1.16.0",
 				},
-				IgnoreDeprecations: tt.args.ignoreDeprecations,
-				IgnoreRemovals:     tt.args.ignoreRemovals,
-				Outputs:            tt.args.outputs,
+				IgnoreDeprecations:            tt.args.ignoreDeprecations,
+				IgnoreRemovals:                tt.args.ignoreRemovals,
+				IgnoreUnavailableReplacements: tt.args.ignoreReplacementUnavailable,
+				Outputs:                       tt.args.outputs,
 			}
 			got := instance.GetReturnCode()
 			assert.Equal(t, tt.want, got)

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -55,6 +55,7 @@ var testVersionDeploymentString = `deprecated-versions:
   deprecated-in: v1.9.0
   removed-in: v1.16.0
   replacement-api: apps/v1
+  replacement-available-in: v1.10.0
   component: k8s
 target-versions:
   k8s: v1.16.0
@@ -62,12 +63,13 @@ target-versions:
   cert-manager: v0.15.1`
 
 var testVersionDeployment = Version{
-	Name:           "extensions/v1beta1",
-	Kind:           "Deployment",
-	DeprecatedIn:   "v1.9.0",
-	RemovedIn:      "v1.16.0",
-	ReplacementAPI: "apps/v1",
-	Component:      "k8s",
+	Name:                   "extensions/v1beta1",
+	Kind:                   "Deployment",
+	DeprecatedIn:           "v1.9.0",
+	RemovedIn:              "v1.16.0",
+	ReplacementAPI:         "apps/v1",
+	ReplacementAvailableIn: "v1.10.0",
+	Component:              "k8s",
 }
 
 func Test_jsonToStub(t *testing.T) {
@@ -425,34 +427,91 @@ func TestVersion_IsRemovedIn(t *testing.T) {
 	}
 }
 
+func TestVersion_isReplacementAvailableIn(t *testing.T) {
+	tests := []struct {
+		name                   string
+		targetVersions         map[string]string
+		component              string
+		want                   bool
+		replacementAvailableIn string
+	}{
+		{
+			name:                   "not available yet 1.15.0",
+			targetVersions:         map[string]string{"foo": "v1.15.0"},
+			component:              "foo",
+			replacementAvailableIn: "v1.16.0",
+			want:                   false,
+		},
+		{
+			name:                   "equal values",
+			targetVersions:         map[string]string{"foo": "v1.16.0"},
+			component:              "foo",
+			replacementAvailableIn: "v1.16.0",
+			want:                   true,
+		},
+		{
+			name:                   "greater than",
+			targetVersions:         map[string]string{"foo": "v1.17.0"},
+			component:              "foo",
+			replacementAvailableIn: "v1.16.0",
+			want:                   true,
+		},
+		{
+			name:                   "bad semVer",
+			targetVersions:         map[string]string{"foo": "foo"},
+			replacementAvailableIn: "v1.16.0",
+			want:                   false,
+		},
+		{
+			name:                   "blank replacementAvailableIn - is available",
+			targetVersions:         map[string]string{"foo": "v1.16.0"},
+			component:              "foo",
+			replacementAvailableIn: "",
+			want:                   true,
+		},
+		{
+			name:                   "targetVersions not included for component",
+			targetVersions:         map[string]string{"one": "v1.16.0"},
+			component:              "two",
+			replacementAvailableIn: "v1.16.0",
+			want:                   false,
+		},
+	}
+	for _, tt := range tests {
+		removedVersion := &Version{ReplacementAvailableIn: tt.replacementAvailableIn, Component: tt.component}
+		got := removedVersion.isReplacementAvailableIn(tt.targetVersions)
+		assert.Equal(t, tt.want, got, "test failed: "+tt.name)
+	}
+}
+
 func ExampleInstance_printVersionsTabular() {
 	instance := Instance{
 		DeprecatedVersions: []Version{
 			testVersionDeployment,
-			{Kind: "testkind", Name: "testname", DeprecatedIn: "", RemovedIn: "", Component: "custom"},
+			{Kind: "testkind", Name: "testname", DeprecatedIn: "", RemovedIn: "", ReplacementAvailableIn: "", Component: "custom"},
 		},
 	}
 	_ = instance.printVersionsTabular()
 
 	// Output:
-	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- COMPONENT--
-	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ k8s--------
-	// testkind---- testname------------ n/a------------ n/a--------- n/a---------- custom-----
+	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- AVAILABLE IN-- COMPONENT--
+	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ v1.10.0------- k8s--------
+	// testkind---- testname------------ n/a------------ n/a--------- n/a---------- n/a----------- custom-----
 }
 
 func ExampleInstance_printVersionsTabular_noHeaders() {
 	instance := Instance{
 		DeprecatedVersions: []Version{
 			testVersionDeployment,
-			{Kind: "testkind", Name: "testname", DeprecatedIn: "", RemovedIn: "", Component: "custom"},
+			{Kind: "testkind", Name: "testname", DeprecatedIn: "", RemovedIn: "", ReplacementAvailableIn: "", Component: "custom"},
 		},
 		NoHeaders: true,
 	}
 	_ = instance.printVersionsTabular()
 
 	// Output:
-	// Deployment-- extensions/v1beta1-- v1.9.0-- v1.16.0-- apps/v1-- k8s-----
-	// testkind---- testname------------ n/a----- n/a------ n/a------ custom--
+	// Deployment-- extensions/v1beta1-- v1.9.0-- v1.16.0-- apps/v1-- v1.10.0-- k8s-----
+	// testkind---- testname------------ n/a----- n/a------ n/a------ n/a------ custom--
 }
 
 func ExampleInstance_PrintVersionList_json() {
@@ -462,7 +521,7 @@ func ExampleInstance_PrintVersionList_json() {
 	_ = instance.PrintVersionList("json")
 
 	// Output:
-	// {"deprecated-versions":[{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","component":"k8s"}]}
+	// {"deprecated-versions":[{"version":"extensions/v1beta1","kind":"Deployment","deprecated-in":"v1.9.0","removed-in":"v1.16.0","replacement-api":"apps/v1","replacement-available-in":"v1.10.0","component":"k8s"}]}
 }
 
 func ExampleInstance_PrintVersionList_yaml() {
@@ -478,6 +537,7 @@ func ExampleInstance_PrintVersionList_yaml() {
 	//       deprecated-in: v1.9.0
 	//       removed-in: v1.16.0
 	//       replacement-api: apps/v1
+	//       replacement-available-in: v1.10.0
 	//       component: k8s
 }
 
@@ -488,8 +548,8 @@ func ExampleInstance_PrintVersionList_normal() {
 	_ = instance.PrintVersionList("normal")
 
 	// Output:
-	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- COMPONENT--
-	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ k8s--------
+	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- AVAILABLE IN-- COMPONENT--
+	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ v1.10.0------- k8s--------
 }
 
 func ExampleInstance_PrintVersionList_wide() {
@@ -499,8 +559,8 @@ func ExampleInstance_PrintVersionList_wide() {
 	_ = instance.PrintVersionList("wide")
 
 	// Output:
-	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- COMPONENT--
-	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ k8s--------
+	// KIND-------- NAME---------------- DEPRECATED IN-- REMOVED IN-- REPLACEMENT-- AVAILABLE IN-- COMPONENT--
+	// Deployment-- extensions/v1beta1-- v1.9.0--------- v1.16.0----- apps/v1------ v1.10.0------- k8s--------
 }
 
 func ExampleInstance_PrintVersionList_badformat() {

--- a/versions.yaml
+++ b/versions.yaml
@@ -238,6 +238,7 @@ deprecated-versions:
     deprecated-in: v1.22.0
     removed-in: v1.25.0
     replacement-api: autoscaling/v2
+    replacement-available-in: v1.23.0
     component: k8s
   - version: autoscaling/v2beta1
     kind: HorizontalPodAutoscalerList


### PR DESCRIPTION
This PR fixes https://github.com/FairwindsOps/pluto/issues/447

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description

If the specifications are acceptable, I would like to update the documentation.

### What's the goal of this PR?

Add an option to ignore Replacements that are deprecated but not yet available in the specified cluster.

### What changes did you make?

- Add `replacement-available-in` to `values.yaml` to check which version of Replacement will be available.
  - If the value is not set, it is evaluated as available to keep backward compatibility.
- Add `--ignore-unavailable-replacements` option to the command to ignore errors if the replacement is deprecated but unavailable.
- Add the boolean `AVAILABLE` and the version string `AVAILABLE IN` to the output.

### What alternative solution should we consider, if any?

I am undecided about the order in which to define the output items and the names of the items.
For csv, I think it would be better to add columns backwards for compatibility, but `AVAILABLE` and `AVAILABLE IN` might be better to be close together since they are items related to `REPLACEMENT`.

As for the name in `values.yaml`, should it be simply `AVAILABLE-IN` rather than `REPLACEMENT-AVAILABLE-IN`, or is another name better?
(I'm not an English speaker, so I'd like to fix this if I get comments)

### Testing

When `test.yaml` and `versions.yaml` is

```yaml
# test.yaml
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: hpa-v2b1
  namespace: example
---
apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  name: hpa-v2b2
  namespace: example

# versions.yaml
  - version: autoscaling/v2beta1
    kind: HorizontalPodAutoscaler
    deprecated-in: v1.22.0
    removed-in: v1.25.0
    replacement-api: autoscaling/v2
    replacement-available-in: v1.23.0
    component: k8s
  - version: autoscaling/v2beta2
    kind: HorizontalPodAutoscaler
    deprecated-in: v1.23.0
    removed-in: v1.26.0
    replacement-api: autoscaling/v2
    component: k8s
```

The following results are returned.

```
$ ./pluto detect-files -t k8s=v1.22.0 -o wide -d test.yaml
NAME       NAMESPACE   KIND                      VERSION               REPLACEMENT      DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN   AVAILABLE   AVAILABLE IN  
hpa-v2b1   example     HorizontalPodAutoscaler   autoscaling/v2beta1   autoscaling/v2   true         v1.22.0         false     v1.25.0      false       v1.23.0       



Want more? Automate Pluto for free with Fairwinds Insights!
 🚀 https://fairwinds.com/insights-signup/pluto 🚀 

$ echo $?                         
2
```

If `--ignore-unavailable-replacements` specified,

```
$ ./pluto detect-files -t k8s=v1.22.0 --ignore-unavailable-replacements -o wide -d test.yaml
NAME       NAMESPACE   KIND                      VERSION               REPLACEMENT      DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN   AVAILABLE   AVAILABLE IN  
hpa-v2b1   example     HorizontalPodAutoscaler   autoscaling/v2beta1   autoscaling/v2   true         v1.22.0         false     v1.25.0      false       v1.23.0       



Want more? Automate Pluto for free with Fairwinds Insights!
 🚀 https://fairwinds.com/insights-signup/pluto 🚀 

$ echo $?
0
```

If `replacement-available-in` is empty, it evaluates to available.

```
$ ./pluto detect-files -t k8s=v1.23.0 --ignore-unavailable-replacements -o wide -d test.yaml
NAME       NAMESPACE   KIND                      VERSION               REPLACEMENT      DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN   AVAILABLE   AVAILABLE IN  
hpa-v2b1   example     HorizontalPodAutoscaler   autoscaling/v2beta1   autoscaling/v2   true         v1.22.0         false     v1.25.0      true        v1.23.0       
hpa-v2b2   example     HorizontalPodAutoscaler   autoscaling/v2beta2   autoscaling/v2   true         v1.23.0         false     v1.26.0      true                      



Want more? Automate Pluto for free with Fairwinds Insights!
 🚀 https://fairwinds.com/insights-signup/pluto 🚀 

$ echo $?
2
```
