### PR TITLE
Add a `detect-all-in-cluster` command to run both `detect-helm` and `detect-api-resources`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -320,7 +320,7 @@ var detectHelmCmd = &cobra.Command{
 		}
 		err = apiInstance.DisplayOutput()
 		if err != nil {
-			fmt.Printf("Error Parsing Output: %v", err)
+			fmt.Printf("Error Parsing Output: %v\n", err)
 			os.Exit(1)
 		}
 		klog.V(5).Infof("retCode: %d", exitCode)
@@ -340,7 +340,7 @@ var detectApiResourceCmd = &cobra.Command{
 		}
 		err = apiInstance.DisplayOutput()
 		if err != nil {
-			fmt.Printf("Error Parsing Output: %v", err)
+			fmt.Printf("Error Parsing Output: %v\n", err)
 			os.Exit(1)
 		}
 		klog.V(5).Infof("retCode: %d", exitCode)
@@ -373,7 +373,7 @@ var detectAllInClusterCmd = &cobra.Command{
 		}
 		err = apiInstance.DisplayOutput()
 		if err != nil {
-			fmt.Printf("Error Parsing Output: %v", err)
+			fmt.Printf("Error Parsing Output: %v\n", err)
 			os.Exit(1)
 		}
 		klog.V(5).Infof("retCode: %d", exitCode)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,3 +61,15 @@ psp                   <UNKNOWN>     PodSecurityPolicy   policy/v1beta1          
 ```
 
 This indicates that the PodSecurityPolicy  was deployed with apps/v1beta1 which is deprecated in 1.21
+
+### helm and API resources (in-cluster)
+
+```
+$ pluto detect-all-in-cluster -o wide 2>/dev/null
+NAME              NAMESPACE   KIND                VERSION                     REPLACEMENT            DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN  
+testing/viahelm   viahelm     Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true         v1.19.0         true      v1.22.0     
+webapp            default     Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true         v1.19.0         true      v1.22.0     
+eks.privileged    <UNKNOWN>   PodSecurityPolicy   policy/v1beta1                                     true         v1.21.0         false     v1.25.0     
+```
+
+This combines all available in-cluster detections, showing results from Helm releases and API resources.


### PR DESCRIPTION

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add a command to Pluto that combines all in-cluster detections - currently `detect-helm` and `detect-api-resources`.

### Sample Output


```
$ ./pluto detect-all-in-cluster 2>/dev/null
NAME              KIND                VERSION                     REPLACEMENT            REMOVED   DEPRECATED  
badhelm/badhelm   Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
webapp            Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
webapp            Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
eks.privileged    PodSecurityPolicy   policy/v1beta1                                     false     true        
```

```
$ ./pluto detect-helm 2>/dev/null
NAME              KIND      VERSION                     REPLACEMENT            REMOVED   DEPRECATED  
badhelm/badhelm   Ingress   networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
```

```
$ ./pluto detect-api-resources 2>/dev/null
NAME             KIND                VERSION                     REPLACEMENT            REMOVED   DEPRECATED  
webapp           Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
webapp           Ingress             networking.k8s.io/v1beta1   networking.k8s.io/v1   true      true        
eks.privileged   PodSecurityPolicy   policy/v1beta1                                     false     true        
```

### What changes did you make?
I moved some code from the Cobra `Run` struct field into reusable functions, so I could call them from the new `detect-all-in-cluster` command.


### What alternative solution should we consider, if any?

Although the `detect-all-in-cluster` command instantiates both a dynamic Kubernetes client and a Helm client, the only duplicated work is calling our kube.GetConfig() function, but determining the KubeConfig file twice is reasonable, compared to retaining it the first time and passing it around.
