### PR TITLE
Add a cosign 2.x command that works to validate the checksums

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,14 @@ release:
   footer: |
     You can verify the signatures of both the checksums.txt file and the published docker images using [cosign](https://github.com/sigstore/cosign).
 
+    cosign 1.x
     ```
     cosign verify-blob checksums.txt --signature=checksums.txt.sig  --key https://artifacts.fairwinds.com/cosign.pub
+    ```
+
+    cosign 2.x
+    ```
+    cosign verify-blob checksums.txt --signature=checksums.txt.sig  --key https://artifacts.fairwinds.com/cosign.pub --insecure-ignore-tlog
     ```
 
     ```


### PR DESCRIPTION
This PR fixes #475

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Update the instructions for verifying the checksums signature for cosign 2.x

### What changes did you make?
Add the `--insecure-ignore-tlog` to the flag

see https://github.com/sigstore/cosign/issues/2808


### What alternative solution should we consider, if any?
long term we can look into transparency log, but I'm not certain that will work with how we manage the signing key in Vault