### PR TITLE
update the default target version of k8s to v1.25

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -544,4 +544,4 @@ deprecated-versions:
 target-versions:
     cert-manager: v1.5.3
     istio: v1.11.0
-    k8s: v1.22.0
+    k8s: v1.25.0


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
The current target version, 1.22, is super old. Let's go newer

### What changes did you make?
Update target-versions in versions.yaml

### What alternative solution should we consider, if any?
n/a