### PR TITLE
Fix using REPL AVAIL/REPL AVAIL IN as custom columns

### DIFF
--- a/pkg/api/columns.go
+++ b/pkg/api/columns.go
@@ -53,6 +53,8 @@ var possibleColumns = []column{
 	new(removedIn),
 	new(component),
 	new(filepath),
+	new(replacementAvailable),
+	new(replacementAvailableIn),
 }
 
 // name is the output name
@@ -181,7 +183,7 @@ func (instance *Instance) wideColumns() columnList {
 
 // customColumns returns a custom list of columns based on names
 func (instance *Instance) customColumns() columnList {
-	var outputColumns = make(map[int]column)
+	outputColumns := make(map[int]column)
 	for i, d := range instance.CustomColumns {
 		for _, c := range possibleColumns {
 			if d == c.header() {


### PR DESCRIPTION
These two were not included in `possibleColumns` and therefore running e.g. `pluto detect-files -o markdown --columns "REPL AVAIL"` would not actually print the column, despite no error being reported.


This PR fixes #514

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix the above issue
### What changes did you make?
Added the two columns in the `possibleColumns` slice
### What alternative solution should we consider, if any?
