### PR TITLE
Fixing isReplacementAvailableIn logic when field available in is empty

### DIFF
--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -84,6 +84,7 @@ var testOutputDeprecatedNotRemoved = &Output{
 		ReplacementAPI: "none",
 		Component:      "foo",
 	},
+	ReplacementAvailable: false,
 }
 
 func init() {
@@ -109,7 +110,7 @@ func ExampleInstance_DisplayOutput_normal() {
 	// NAME-------------------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED-- REPL AVAIL--
 	// some name one----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true--------
 	// some name two----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true--------
-	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true-------- true--------
+	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true-------- false--------
 }
 
 func ExampleInstance_DisplayOutput_onlyShowRemoved() {

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -411,7 +411,7 @@ func TestGetReturnCode(t *testing.T) {
 				ignoreRemovals:               false,
 				ignoreReplacementUnavailable: false,
 			},
-			want: 2,
+			want: 4,
 		},
 		{
 			name: "version is deprecated ignore deprecations",
@@ -429,7 +429,7 @@ func TestGetReturnCode(t *testing.T) {
 				ignoreRemovals:               false,
 				ignoreReplacementUnavailable: false,
 			},
-			want: 0,
+			want: 4,
 		},
 		{
 			name: "version is removed",
@@ -447,7 +447,7 @@ func TestGetReturnCode(t *testing.T) {
 				ignoreRemovals:               false,
 				ignoreReplacementUnavailable: false,
 			},
-			want: 3,
+			want: 4,
 		},
 		{
 			name: "version is removed and replacement is unavailable",

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -110,7 +110,7 @@ func ExampleInstance_DisplayOutput_normal() {
 	// NAME-------------------- KIND-------- VERSION------------- REPLACEMENT-- REMOVED-- DEPRECATED-- REPL AVAIL--
 	// some name one----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true--------
 	// some name two----------- Deployment-- extensions/v1beta1-- apps/v1------ true----- true-------- true--------
-	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true-------- false--------
+	// deprecated not removed-- Deployment-- apps/v1------------- none--------- false---- true-------- false-------
 }
 
 func ExampleInstance_DisplayOutput_onlyShowRemoved() {

--- a/pkg/api/versions.go
+++ b/pkg/api/versions.go
@@ -253,7 +253,7 @@ func (v *Version) isReplacementAvailableIn(targetVersions map[string]string) boo
 	}
 
 	if v.ReplacementAvailableIn == "" {
-		return true
+		return false
 	}
 
 	targetVersion, ok := targetVersions[v.Component]

--- a/pkg/api/versions_test.go
+++ b/pkg/api/versions_test.go
@@ -467,7 +467,7 @@ func TestVersion_isReplacementAvailableIn(t *testing.T) {
 			targetVersions:         map[string]string{"foo": "v1.16.0"},
 			component:              "foo",
 			replacementAvailableIn: "",
-			want:                   true,
+			want:                   false,
 		},
 		{
 			name:                   "targetVersions not included for component",


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fixing logic for isReplacementAvailableIn  when field availableIn is empty
### What changes did you make?
Updated isReplacementAvailableIn  function
### What alternative solution should we consider, if any?

