### PR TITLE
Bump goreleaser version to 1.22.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
     resource_class: large
     shell: /bin/bash
     docker:
-      - image: goreleaser/goreleaser:v1.18.2
+      - image: goreleaser/goreleaser:v1.22.1
         environment:
           GO111MODULE: "on"
     steps:
@@ -79,7 +79,7 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/fairwindsops/pluto
     resource_class: large
     docker:
-      - image: goreleaser/goreleaser:v1.18.2
+      - image: goreleaser/goreleaser:v1.22.1
     steps:
       - checkout
       - setup_remote_docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 brews:
   - name: pluto
     goarm: 6
-    tap:
+    repository:
       owner: FairwindsOps
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
This PR fixes #
Bump goreleaser version to build Pluto with newer Go version

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Build Pluto with a newer GO version due to vulnerabilities in Go 1.20.4

### What changes did you make?
* Update goreleaser container image from 1.18.2 to 1.22.1
* Update `.goreleaser.yml` due to a [depreciation of `tap`](https://goreleaser.com/deprecations/?h=depre#brewstap) in goreleaser version 1.19.0

## Verifications
* I've used the goreleaser image locally to build Pluto and verify the build pass successfully.
* Verified Pluto binary for `Darwin` was built with newer GO version (1.21.3)
* Verified Pluto is running on a test cluster

### What alternative solution should we consider, if any?

