### PR TITLE
Accept signature for cosign

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,8 @@ checksum:
   name_template: "checksums.txt"
 
 signs:
-- cmd: cosign
-  args: ["sign-blob", "--key=hashivault://cosign", "-output-signature=${signature}", "${artifact}"]
+- cmd: sh
+  args: ["-c", "echo 'y' | cosign sign-blob --key=hashivault://cosign --output-signature ${signature} ${artifact}"]
   artifacts: checksum
 
 docker_signs:


### PR DESCRIPTION
Release step is failing with;

error=sign: cosign failed: exit status 1: WARNING: the -output-signature=dist/checksums.txt.sig flag is deprecated and will be removed in a future release. Please use the --output-signature=dist/checksums.txt.sig flag instead.
Using payload from: dist/checksums.txt

This update uses the non-deprecated command and also accepts the sig.


This PR fixes #

## Checklist
* [*] I have signed the CLA
* [*] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To fix the failing circleci build

### What changes did you make?
Added in a -y to accept the signature and updated the deprecated -output-signature

### What alternative solution should we consider, if any?
Not looked at other options
