### PR TITLE
fix(cosign): fix deprecated flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ checksum:
 
 signs:
 - cmd: cosign
-  args: ["sign-blob", "--key=hashivault://cosign", "-output-signature=${signature}", "${artifact}"]
+  args: ["sign-blob", "--key=hashivault://cosign", "--output-signature=${signature}", "${artifact}"]
   artifacts: checksum
 
 docker_signs:


### PR DESCRIPTION
address error=sign: cosign failed: exit status 1: WARNING: the -output-signature=dist/checksums.txt.sig flag is deprecated and will be removed in a future release. Please use the --output-signature=dist/checksums.txt.sig flag instead.


This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix cosign flag

### What changes did you make?
changed -output to --output

### What alternative solution should we consider, if any?

