### PR TITLE
fix(release): another attempt to fix the release step

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ checksum:
 
 signs:
 - cmd: sh
-  args: ["-c", "echo 'y' | cosign sign-blob --key=hashivault://cosign --output-signature ${signature} ${artifact}"]
+  args: ["-c", "echo 'y' | cosign sign-blob --key=hashivault://cosign --output-signature ${signature} ${digest}"]
   artifacts: checksum
 
 docker_signs:


### PR DESCRIPTION
changing `{artifact}` in `signs` cmd to `{digest}`


This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix the release step which is currently fails with error message
```
error=signing docker images: failed to publish artifacts: sign: cosign failed: exit status 1: WARNING: Image reference sha256:424fa83f860fe96d1966c0d1cab7c62fc06d36a2e763bad1d8ce004cca306ada uses a tag, not a digest, to identify the image to sign.
```
and
```
Error: signing [sha256:424fa83f860fe96d1966c0d1cab7c62fc06d36a2e763bad1d8ce004cca306ada]: accessing entity: GET https://index.docker.io/v2/library/sha256/manifests/424fa83f860fe96d1966c0d1cab7c62fc06d36a2e763bad1d8ce004cca306ada: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/sha256 Type:repository]]
main.go:74: error during command execution: signing [sha256:424fa83f860fe96d1966c0d1cab7c62fc06d36a2e763bad1d8ce004cca306ada]: accessing entity: GET https://index.docker.io/v2/library/sha256/manifests/424fa83f860fe96d1966c0d1cab7c62fc06d36a2e763bad1d8ce004cca306ada: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/sha256 Type:repository]]
```

### What changes did you make?
`${artifact}` to `${digest}` in `signs` section

### What alternative solution should we consider, if any?

