### PR TITLE
fix #432 don't compare when object kind doesn't match kind in last-ap…

### DIFF
--- a/pkg/discovery-api/discovery_api.go
+++ b/pkg/discovery-api/discovery_api.go
@@ -145,6 +145,10 @@ func (cl *DiscoveryClient) GetApiResources() error {
 						klog.Errorf("failed to parse 'last-applied-configuration' annotation of resource %s/%s: %s", r.GetNamespace(), r.GetName(), err.Error())
 						continue
 					}
+					if r.Object["kind"] != manifest["kind"] {
+						klog.V(2).Infof("Object Kind %s does not match last-applied-configuration-kind %s. Skipping", r.Object["kind"], manifest["kind"])
+						continue
+					}
 					data, err := json.Marshal(manifest)
 					if err != nil {
 						klog.Error("Failed to marshal data ", err.Error())


### PR DESCRIPTION
…plied-configuration


This PR fixes #432

## Checklist
* [X] I have signed the CLA
* [N/A] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Some objects, like controllerrevisions, were being reported as daemonsets with deprecated apiVersions. This PR prevents that.

### What changes did you make?

Created a condition that looks for any objects where the object kind does not match the kind in the last-applied-configuration metadata. If true, excludes the object from the list of objects with deprecated api versions.

### What alternative solution should we consider, if any?
