### PR TITLE
fix: remove tag annotation requirement

### DIFF
--- a/docs/contributing/guide.md
+++ b/docs/contributing/guide.md
@@ -96,7 +96,7 @@ There is a Makefile that can assist in validating and testing the orb locally.  
 
 ## Creating a new release
 
-Push a new annotated tag.  This tag should contain a changelog of pertinent changes. Goreleaser will take care of the rest.
+Push a new tag and Goreleaser will take care of the rest.
 
 ## Pre-commit
 


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Annotated tags are no longer necessary for releases.

### What changes did you make?

Changed the contribution documentation to reflect the change.

### What alternative solution should we consider, if any?

