### PR TITLE
fix(release): update goreleaser to 2.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   golang-exec:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.23
 
 references:
   e2e_config: &e2e_config
@@ -48,7 +48,7 @@ jobs:
   test:
     working_directory: /home/circleci/go/src/github.com/fairwindsops/pluto
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.23
     steps:
       - checkout
       - run: go mod download && go mod verify
@@ -58,7 +58,7 @@ jobs:
     resource_class: large
     shell: /bin/bash
     docker:
-      - image: goreleaser/goreleaser:v1.26.2
+      - image: goreleaser/goreleaser:v2.2.0
         environment:
           GO111MODULE: "on"
     steps:
@@ -79,11 +79,11 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/fairwindsops/pluto
     resource_class: large
     docker:
-      - image: goreleaser/goreleaser:v1.26.2
+      - image: goreleaser/goreleaser:v2.2.0
     steps:
       - checkout
       - setup_remote_docker
-      - run: goreleaser --snapshot --skip-sign
+      - run: goreleaser --snapshot --skip=sign
       - store_artifacts:
           path: dist
           destination: snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   golang-exec:
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.22
 
 references:
   e2e_config: &e2e_config
@@ -48,7 +48,7 @@ jobs:
   test:
     working_directory: /home/circleci/go/src/github.com/fairwindsops/pluto
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.22
     steps:
       - checkout
       - run: go mod download && go mod verify

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,11 @@
+version: 2
 brews:
   - name: pluto
     goarm: 6
     repository:
       owner: FairwindsOps
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     description: Detect deprecated Kubernetes apiVersions
     test: |
       system "#{bin}/pluto version"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/fairwindsops/pluto/v5
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.23.0
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fairwindsops/pluto/v5
 
-go 1.23.0
+go 1.22.6
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5


### PR DESCRIPTION
This PR fixes #549 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Upgrade the version of Goreleaser following the [upgrade guide](https://goreleaser.com/blog/goreleaser-v2/#upgrading)

### What changes did you make?
- Use most recent release of Go `v1.22`
- Modify `.goreleaser.yml` to use new v2 syntax

### What alternative solution should we consider, if any?
Remaining on deprecated version