### PR TITLE
ci, feat - allow explicitly setting the container image

### DIFF
--- a/.github/workflows/github-action-test.yml
+++ b/.github/workflows/github-action-test.yml
@@ -11,8 +11,6 @@ jobs:
 
       - name: Download pluto
         uses: ./github-action
-        with:
-          CONTAINER_ENGINE: docker
 
       - name: Pluto exists?
         run: |


### PR DESCRIPTION
but if it's not set, use podman, fall back to docker


This PR fixes #576

## Checklist

* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

TO intelligently select between `docker` or `podman` for pulling down the container image containing `pluto`

### What changes did you make?



### What alternative solution should we consider, if any?

