### PR TITLE
fix: opt into fixed klog stderrthreshold behavior

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,6 +117,11 @@ func init() {
 	rootCmd.AddCommand(detectCmd)
 
 	klog.InitFlags(nil)
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default).
+	// Ref: kubernetes/klog#212, kubernetes/klog#432
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false") //nolint:errcheck
+	_ = flag.Set("stderrthreshold", "INFO")                   //nolint:errcheck
 	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
 }
 


### PR DESCRIPTION
## Problem

klog v2 defaults `-logtostderr` to `true`. When this flag is active, the `-stderrthreshold` flag is **silently ignored** — all log messages of every severity (INFO, WARNING, ERROR, FATAL) are unconditionally written to stderr.

This makes it impossible for log-aggregation systems (Fluentd, Fluent Bit, Loki, Datadog, etc.) to filter logs by severity on the stderr stream.

This has been an open issue since 2020: kubernetes/klog#212

## Fix

klog v2.140.0 introduced a new `legacy_stderr_threshold_behavior` flag (kubernetes/klog#432). Setting it to `false` makes `-stderrthreshold` work correctly even when `-logtostderr=true`.

This PR opts pluto into the fixed behavior by setting `legacy_stderr_threshold_behavior=false` after `klog.InitFlags()` in `cmd/root.go`. The default `stderrthreshold` remains `INFO` so the observable behavior is **unchanged** — all logs still go to stderr by default. Users who want filtering can now pass `-stderrthreshold=WARNING` or `-stderrthreshold=ERROR` and it will actually take effect.

## References

- Upstream issue: kubernetes/klog#212
- Upstream fix: kubernetes/klog#432