### PR TITLE
fix: suppress kube api warnings

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -90,6 +90,9 @@ func GetConfig(kubeContext string, kubeConfigPath string) (*rest.Config, error) 
 		return nil, err
 	}
 
+	// Suppress deprecation warnings from the Kubernetes API server
+	kubeConfig.WarningHandler = rest.NoWarnings{}
+
 	return kubeConfig, nil
 }
 


### PR DESCRIPTION
This PR fixes #603

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Suppress kube api warnings