### PR TITLE
Add --ignore-kinds flag to exclude resource kinds from results

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ var (
 	targetVersions                map[string]string
 	customColumns                 []string
 	componentsFromUser            []string
+	ignoredKinds                  []string
 	onlyShowRemoved               bool
 	kubeContext                   string
 	noHeaders                     bool
@@ -94,6 +95,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "normal", "The output format to use. (normal|wide|custom|json|yaml|markdown|csv)")
 	rootCmd.PersistentFlags().StringSliceVar(&customColumns, "columns", nil, "A list of columns to print. Mandatory when using --output custom, optional with --output markdown")
 	rootCmd.PersistentFlags().StringSliceVar(&componentsFromUser, "components", nil, "A list of components to run checks for. If nil, will check for all found in versions.")
+	rootCmd.PersistentFlags().StringSliceVar(&ignoredKinds, "ignore-kinds", nil, "A list of resource kinds to exclude from the results (e.g. CronJob,Ingress).")
 
 	rootCmd.AddCommand(detectFilesCmd)
 	detectFilesCmd.PersistentFlags().StringVarP(&directory, "directory", "d", "", "The directory to scan. If blank, defaults to current working dir.")
@@ -288,6 +290,7 @@ var rootCmd = &cobra.Command{
 			NoHeaders:                     noHeaders,
 			DeprecatedVersions:            deprecatedVersionList,
 			Components:                    componentList,
+			IgnoredKinds:                  ignoredKinds,
 		}
 
 		return nil

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -161,6 +161,10 @@ Notice that there is no output, despite the fact that we might have recognized a
 
 By default Pluto will scan for all components in the versionsList that it can find. If you wish to only see deprecations for a specific component, you can use the `--components` flag to specify a list.
 
+## Ignore Kinds
+
+If you wish to exclude specific resource kinds from the results, you can use the `--ignore-kinds` flag to specify a list. For example, `--ignore-kinds CronJob,Ingress` will hide any detections for kinds named `CronJob` or `Ingress`. The match is case-sensitive and applies to the kind of the deprecated apiVersion.
+
 ## Only Show Removed
 
 If you are targeting an upgrade, you may only wish to see apiVersions that have been `removed` rather than both `deprecated` and `removed`. You can pass the `--only-show-removed` or `-r` flag for this. It will remove any detections that are deprecated, but not yet removed. This will affect the exit code of the command as well as the json and yaml output.
@@ -223,4 +227,5 @@ All environment variables are prefixed with `PLUTO` and use `_` instead of `-`.
 | --output              | PLUTO_OUTPUT              |
 | --columns             | PLUTO_COLUMNS             |
 | --components          | PLUTO_COMPONENTS          |
+| --ignore-kinds        | PLUTO_IGNORE_KINDS        |
 | --no-headers          | PLUTO_NO_HEADERS          |

--- a/pkg/api/output.go
+++ b/pkg/api/output.go
@@ -66,6 +66,7 @@ type Instance struct {
 	DeprecatedVersions            []Version         `json:"-" yaml:"-"`
 	CustomColumns                 []string          `json:"-" yaml:"-"`
 	Components                    []string          `json:"-" yaml:"-"`
+	IgnoredKinds                  []string          `json:"-" yaml:"-"`
 }
 
 // DisplayOutput prints the output based on desired variables
@@ -156,6 +157,10 @@ func (instance *Instance) DisplayOutput() error {
 func (instance *Instance) FilterOutput() {
 	var usableOutputs []*Output
 	for _, output := range instance.Outputs {
+		// skip any kinds that the user has asked to ignore
+		if StringInSlice(output.APIVersion.Kind, instance.IgnoredKinds) {
+			continue
+		}
 		output.Deprecated = output.APIVersion.isDeprecatedIn(instance.TargetVersions)
 		output.Removed = output.APIVersion.isRemovedIn(instance.TargetVersions)
 		output.ReplacementAvailable = output.APIVersion.isReplacementAvailableIn(instance.TargetVersions)

--- a/pkg/api/output_test.go
+++ b/pkg/api/output_test.go
@@ -523,3 +523,70 @@ func TestGetReturnCode(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterOutput(t *testing.T) {
+	newOutputs := func() []*Output {
+		return []*Output{
+			{
+				Name: "cronjob one",
+				APIVersion: &Version{
+					Name:         "batch/v1beta1",
+					Kind:         "CronJob",
+					DeprecatedIn: "v1.21.0",
+					RemovedIn:    "v1.25.0",
+					Component:    "k8s",
+				},
+			},
+			{
+				Name: "ingress one",
+				APIVersion: &Version{
+					Name:         "extensions/v1beta1",
+					Kind:         "Ingress",
+					DeprecatedIn: "v1.14.0",
+					RemovedIn:    "v1.22.0",
+					Component:    "k8s",
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		ignoredKinds []string
+		wantNames    []string
+	}{
+		{
+			name:         "no ignored kinds keeps everything",
+			ignoredKinds: nil,
+			wantNames:    []string{"cronjob one", "ingress one"},
+		},
+		{
+			name:         "ignored kind is excluded",
+			ignoredKinds: []string{"CronJob"},
+			wantNames:    []string{"ingress one"},
+		},
+		{
+			name:         "all kinds ignored",
+			ignoredKinds: []string{"CronJob", "Ingress"},
+			wantNames:    []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &Instance{
+				Outputs:        newOutputs(),
+				TargetVersions: map[string]string{"k8s": "v1.26.0"},
+				Components:     []string{"k8s"},
+				IgnoredKinds:   tt.ignoredKinds,
+			}
+			instance.FilterOutput()
+
+			gotNames := []string{}
+			for _, o := range instance.Outputs {
+				gotNames = append(gotNames, o.Name)
+			}
+			assert.Equal(t, tt.wantNames, gotNames)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #399

Adds an `--ignore-kinds` flag that excludes specific resource kinds from the results, as discussed in the issue:

> I think adding that flag could be useful as well

It mirrors the existing `--components` filter semantics: a `StringSlice` flag threaded into the API instance, applied in `FilterOutput` against the kind of the matched deprecated apiVersion. The match is case-sensitive (`CronJob`, `Ingress`, ...). Since flags are bound automatically, `PLUTO_IGNORE_KINDS` works as well and is documented alongside the flag in `docs/advanced.md`.

Scope note: this deliberately doesn't touch the custom-versions-file discussion from the second comment on the issue — that's a separate concern.

### Testing

Added a table-driven `TestFilterOutput` covering: no ignored kinds (unchanged behavior), one kind excluded, all kinds excluded.

```
go test ./pkg/api/ -run TestFilterOutput
```
