### PR TITLE
[#615] Update deprecations list

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -351,6 +351,34 @@ deprecated-versions:
     deprecated-in: v1.6.0
     removed-in: v1.22.0
     component: k8s
+  - version: authorization.k8s.io/v1beta1
+    kind: LocalSubjectAccessReview
+    replacement-api: authorization.k8s.io/v1
+    replacement-available-in: v1.6.0
+    deprecated-in: v1.19.0
+    removed-in: v1.22.0
+    component: k8s
+  - version: authorization.k8s.io/v1beta1
+    kind: SelfSubjectAccessReview
+    replacement-api: authorization.k8s.io/v1
+    replacement-available-in: v1.6.0
+    deprecated-in: v1.19.0
+    removed-in: v1.22.0
+    component: k8s
+  - version: authorization.k8s.io/v1beta1
+    kind: SubjectAccessReview
+    replacement-api: authorization.k8s.io/v1
+    replacement-available-in: v1.6.0
+    deprecated-in: v1.19.0
+    removed-in: v1.22.0
+    component: k8s
+  - version: authorization.k8s.io/v1beta1
+    kind: SelfSubjectRulesReview
+    replacement-api: authorization.k8s.io/v1
+    replacement-available-in: v1.6.0
+    deprecated-in: v1.19.0
+    removed-in: v1.22.0
+    component: k8s
   - version: certificates.k8s.io/v1beta1
     kind: CertificateSigningRequest
     deprecated-in: v1.19.0


### PR DESCRIPTION
## Summary

This PR updates the deprecations list in `versions.yaml` by adding four missing Kubernetes API deprecations that were removed in v1.22.

## Changes Made

Added the following missing `authorization.k8s.io/v1beta1` API deprecations:

1. **LocalSubjectAccessReview** - deprecated in v1.19.0, removed in v1.22.0
2. **SelfSubjectAccessReview** - deprecated in v1.19.0, removed in v1.22.0
3. **SubjectAccessReview** - deprecated in v1.19.0, removed in v1.22.0
4. **SelfSubjectRulesReview** - deprecated in v1.19.0, removed in v1.22.0

All four APIs have replacement API `authorization.k8s.io/v1` which has been available since v1.6.0.

## Background

These deprecations were identified by reviewing the official [Kubernetes Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/). The `authorization.k8s.io/v1beta1` API version of these resources was no longer served as of Kubernetes v1.22.

## Validation

- YAML syntax validated successfully
- Maintains consistency with existing deprecation entry format
- Total deprecation count increased from 112 to 116 entries

## Reviewer Notes

Please verify that:
- The deprecation version information is accurate according to Kubernetes release notes
- The format matches existing entries in the file
- The placement of new entries is logical (grouped with other authorization-related APIs)

Closes #615

_This pull request was opened by an AI agent (OpenHands)._
